### PR TITLE
7902535: Code coverage does not work in JDK 8

### DIFF
--- a/src/classes/com/sun/tdk/jcov/runtime/CollectDetect.java
+++ b/src/classes/com/sun/tdk/jcov/runtime/CollectDetect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class CollectDetect extends Collect {
      */
     private static class ThreadInfo {
 
-        public static int MAX_STACK = 1000; // not used
+        private static int INFO_LENGTH = 100;
         long id; // thread id
         int instLevel; // not-zero instLevel means that this thread entered into instrumentation (agent) or saving code when it shouldn't collect hits
         int expected = 0; // used for CallerInclude/CallerExclude - caller() method is instrumented with setExpected() method
@@ -76,16 +76,25 @@ public class CollectDetect extends Collect {
     static volatile boolean lock = false;
 
     static {
+        CollectDetect.init();
+        CollectDetect.enableInvokeCounts();
+    }
+
+    public static void init() {
         if (info == null) {
             // do initialization
             underConstruction = new ThreadInfo(0L);
             underConstruction.instLevel++;
             if (Thread.currentThread() != null) {
-                info = new ThreadInfo[100];
+                info = new ThreadInfo[ThreadInfo.INFO_LENGTH];
                 long id = Thread.currentThread().getId();
                 prevInfo = infoForThread(id);
             }
         }
+    }
+
+    public static void enableInvokeCounts() {
+        invokeCounts = new long[MAX_SLOTS];
     }
 
     public static void enableDetectInternal() {
@@ -93,7 +102,7 @@ public class CollectDetect extends Collect {
             // do initialization
             underConstruction = new ThreadInfo(0L);
             underConstruction.instLevel++;
-            info = new ThreadInfo[100];
+            info = new ThreadInfo[ThreadInfo.INFO_LENGTH];
             long id = Thread.currentThread().getId();
             prevInfo = infoForThread(id);
         }
@@ -101,7 +110,10 @@ public class CollectDetect extends Collect {
 
     private static ThreadInfo infoForThread(long id) {
         ThreadInfo ti;
-        int hash = (int) (id % info.length);
+        if( info == null ) {
+            info = new ThreadInfo[ThreadInfo.INFO_LENGTH];
+        }
+        int hash = (int) (id % ThreadInfo.INFO_LENGTH);
         for (ti = info[hash]; ti != null; ti = ti.next) {
             if (ti.id == id) {
                 prevInfo = ti;
@@ -124,33 +136,39 @@ public class CollectDetect extends Collect {
     }
 
     public static void hit(int slot) {
-        //lock = true;
-        long id = Thread.currentThread().getId();
-        ThreadInfo ti = prevInfo;
+        Thread t = Thread.currentThread();
+        if ( t != null ) {
+            long id = Thread.currentThread().getId();
+            ThreadInfo ti = prevInfo;
 
-        if (ti.id != id) {
-            ti = infoForThread(id);
-        }
-        if (ti.enabled()) {
-            Collect.hit(slot);
+            if (ti.id != id) {
+                ti = infoForThread(id);
+            }
+
+            if (ti.enabled()) {
+                Collect.hit(slot);
+            }
         }
     }
 
     public static void hit(int slot, int hash, int fullHash) {
+        Thread t = Thread.currentThread();
+        if( t != null ) {
+            long id = t.getId();
+            ThreadInfo ti = prevInfo;
 
-        long id = Thread.currentThread().getId();
-        ThreadInfo ti = prevInfo;
+            if (ti == null || ti.id != id) {
+                ti = infoForThread(id);
+            }
 
-        if (ti.id != id) {
-            ti = infoForThread(id);
-        }
-        if (ti.enabled(hash)) {
-            ti.expected = 0;
-            Collect.hit(slot);
-        }
-        if (ti.enabledFull(fullHash)) {
-            ti.expectedFull = 0;
-            Collect.hit(slot);
+            if (ti.enabled(hash)) {
+                ti.expected = 0;
+                Collect.hit(slot);
+            }
+            if (ti.enabledFull(fullHash)) {
+                ti.expectedFull = 0;
+                Collect.hit(slot);
+            }
         }
     }
 
@@ -227,9 +245,6 @@ public class CollectDetect extends Collect {
     }
     private static long[] invokeCounts;
 
-    public static void enableInvokeCounts() {
-        invokeCounts = new long[MAX_SLOTS];
-    }
 
     public static void invokeHit(int id) {
         invokeCounts[id]++;
@@ -245,9 +260,5 @@ public class CollectDetect extends Collect {
 
     public static void setInvokeCountFor(int id, long count) {
         invokeCounts[id] = count;
-    }
-
-    static {
-        enableInvokeCounts();
     }
 }

--- a/src/classes/com/sun/tdk/jcov/runtime/JCovSESocketSaver.java
+++ b/src/classes/com/sun/tdk/jcov/runtime/JCovSESocketSaver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,10 +43,16 @@ public class JCovSESocketSaver extends JCovSocketSaver {
     public static final String HOST_PROPERTIES_NAME = "host";
 
     static {
-
+        URL url = null;
         File file = null;
         String urlString = "";
-        URL url = ClassLoader.getSystemClassLoader().getResource(JCovSESocketSaver.class.getCanonicalName().replaceAll("\\.", "/") + ".class");
+        try {
+            url = ClassLoader.getSystemClassLoader().getResource(
+                    JCovSESocketSaver.class.
+                            getCanonicalName().
+                            replace('.', '/') + ".class");
+        } catch( Exception ignore ) {
+        }
         if (url != null) {
             urlString = url.toString();
             if (urlString.contains("file:") && urlString.contains("!")) {
@@ -61,13 +67,20 @@ public class JCovSESocketSaver extends JCovSocketSaver {
             }
         }
 
-        if (file == null){
-            file = new File(System.getProperty("java.home")+File.separator + NETWORK_DEF_PROPERTIES_FILENAME);
+        if (file == null) {
+            try {
+                file = new File(System.getProperty("java.home") +
+                        File.separator +
+                        NETWORK_DEF_PROPERTIES_FILENAME);
+            } catch( Exception ignore ) {
+            }
         }
 
         if (file != null && file.exists()) {
 
-            File defProperties = new File(file.getParent() + File.separator + NETWORK_DEF_PROPERTIES_FILENAME);
+            File defProperties = new File(file.getParent() +
+                    File.separator +
+                    NETWORK_DEF_PROPERTIES_FILENAME);
 
             if (defProperties.exists()) {
 

--- a/src/classes/com/sun/tdk/jcov/runtime/JCovServerSocketSaver.java
+++ b/src/classes/com/sun/tdk/jcov/runtime/JCovServerSocketSaver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ class JCovServerSocketSaver implements JCovSaver {
     static int detectPort() {
         String p = null;
         try {
-            p = PropertyFinder.findValue(PORT, "" + DEFAULT_PORT);
+            p = PropertyFinder.findValue(PORT, String.valueOf(DEFAULT_PORT));
             return Integer.parseInt(p);
         } catch (NumberFormatException e) {
             System.err.println("JCovRT: Port parse error (not a number) " + p);

--- a/src/classes/com/sun/tdk/jcov/runtime/PropertyFinder.java
+++ b/src/classes/com/sun/tdk/jcov/runtime/PropertyFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,10 @@ package com.sun.tdk.jcov.runtime;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Calendar;
-import java.util.Iterator;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -68,7 +66,7 @@ public final class PropertyFinder {
         if (str == null) {
             return str;
         }
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int start = 0, pos = 0;
         while (true) {
             pos = str.indexOf('%', start);
@@ -101,11 +99,18 @@ public final class PropertyFinder {
                         switch (ch) {
                             case 'd': // M-D-Y
                                 Calendar c = Calendar.getInstance();
-                                buf.append(c.get(Calendar.HOUR_OF_DAY)).append(':').append(c.get(Calendar.MINUTE)).append(':').append(c.get(Calendar.SECOND)).append('_').append(c.get(Calendar.MONTH) + 1).append('-').append(c.get(Calendar.DAY_OF_MONTH)).append('-').append(c.get(Calendar.YEAR));
+                                buf.append(c.get(Calendar.HOUR_OF_DAY)).append(':').
+                                        append(c.get(Calendar.MINUTE)).append(':').
+                                        append(c.get(Calendar.SECOND)).append('_').
+                                        append(c.get(Calendar.MONTH) + 1).append('-').
+                                        append(c.get(Calendar.DAY_OF_MONTH)).append('-').
+                                        append(c.get(Calendar.YEAR));
                                 break;
                             case 't': // h:m:s
                                 c = Calendar.getInstance();
-                                buf.append(c.get(Calendar.HOUR_OF_DAY)).append(':').append(c.get(Calendar.MINUTE)).append(':').append(c.get(Calendar.SECOND));
+                                buf.append(c.get(Calendar.HOUR_OF_DAY)).append(':').
+                                        append(c.get(Calendar.MINUTE)).append(':').
+                                        append(c.get(Calendar.SECOND));
                                 break;
                             case 'D': // VM workdir
                                 buf.append(System.getProperty("user.dir"));
@@ -180,16 +185,8 @@ public final class PropertyFinder {
                         --end; // including last % to next search
                         buf.append(patt);
                     }
-                } else if (ch == 'E') { // environment variable
+                } else if (ch == 'E' || ch == 'P') { // environment variable or Java property
                     String prop = System.getenv(patt.substring(2));
-                    if (prop != null) {
-                        buf.append(prop);
-                    } else {
-                        --end; // including last % to next search
-                        buf.append(patt);
-                    }
-                } else if (ch == 'P') { // Java property
-                    String prop = System.getProperty(patt.substring(2));
                     if (prop != null) {
                         buf.append(prop);
                     } else {
@@ -214,7 +211,7 @@ public final class PropertyFinder {
     private static boolean propsRead = false;
     private static String propsFile;
     public static final String PROPERTY_FILE_PREFIX = "jcov.";
-    public static final String JVM_PROPERTY_PREFIX = "jcov.";
+    public static final String JVM_PROPERTY_PREFIX = PROPERTY_FILE_PREFIX;
     public static final String ENV_PROPERTY_PREFIX = "JCOV_";
 
     /**
@@ -229,16 +226,15 @@ public final class PropertyFinder {
      */
     public static String getStaticValue(String name, String defaultValue) {
         try {
-            String res = System.getProperty("jcov." + name);
+            String res = System.getProperty(PROPERTY_FILE_PREFIX + name);
             if (res != null) {
                 return res;
             }
-
-            res = System.getenv("JCOV_" + name.replaceAll("\\.", "_").toUpperCase());
+            res = System.getenv(ENV_PROPERTY_PREFIX + name.replace('.', '_').toUpperCase());
             if (res != null) {
                 return res;
             }
-        } catch (RuntimeException e) {
+        } catch (Exception ignored) {
         }
         return defaultValue;
     }
@@ -302,125 +298,69 @@ public final class PropertyFinder {
                 }
             }
 
-            p = readProperties(System.getProperty("user.home") + File.separator + ".jcov" + File.separator + "jcov.properties");
-            if (p != null) {
-                propsFile = System.getProperty("user.home") + File.separator + ".jcov" + File.separator + "jcov.properties";
+            try {
+                p = readProperties(System.getProperty("user.home") + File.separator + ".jcov" + File.separator + "jcov.properties");
+                if (p != null) {
+                    propsFile = System.getProperty("user.home") + File.separator + ".jcov" + File.separator + "jcov.properties";
+                }
+            } catch (Exception ignore) {
             }
         }
 
         return p;
     }
 
+    private static Properties loadPropertiesFile(String path, Properties properties) {
+        try(InputStream in = new FileInputStream(path)) {
+            Properties p = ( properties == null) ?  new Properties() : properties;
+            p.load(in);
+            resolveProps(p);
+            properties = p;
+        } catch (Exception ignore) {
+            // warning message
+        }
+        return properties;
+    }
+
+    private static Properties loadPropertiesStream(String path, Properties properties) {
+        try(InputStream in = JCovSaver.class.getResourceAsStream(path)) {
+            Properties p = ( properties == null) ?  new Properties() : properties;
+            p.load(in);
+            resolveProps(p);
+            properties = p;
+        } catch (Exception ignore) {
+            // warning message
+        }
+        return properties;
+    }
+
     /**
-     * <p> Reads jcov property file from specified path </p> <p> Path is firstly
-     * checked as a file and is read only if such file exists and can be read.
-     * If it's not a file, can't be read, doesn't exist or is not a property
-     * file then classpath resource is checked. <p>
+     * <p> Reads jcov property file from specified path </p> <p>
+     * If it can't be read then classpath resource is checked. <p>
      *
      * @param path Path to look for a property file.
      * @return Read properties or null if file was not found neither in file
      * system neither in classpath
      */
     public static Properties readProperties(String path) {
-        File f = new File(path);
-        if (f.exists() && f.isFile() && f.canRead()) {
-            InputStream in = null;
-            try {
-                in = new FileInputStream(f);
-                Properties p = new Properties();
-                p.load(in);
-                resolveProps(p);
-                return p;
-            } catch (IOException ex) {
-                // warning message
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (Exception e) {
-                    }
-                }
-            }
-        }
-
-        InputStream in = null;
-        try {
-            in = JCovSaver.class.getResourceAsStream(path);
-        }
-        catch (Exception e){
-            //in will be null
-        }
-        if (in != null) {
-            try {
-                Properties p = new Properties();
-                p.load(in);
-                resolveProps(p);
-                return p;
-            } catch (IOException e) {
-                // warning message
-            } finally {
-                try {
-                    in.close();
-                } catch (Exception e) {
-                }
-            }
-        }
-
-        return null;
+        Properties p = loadPropertiesFile(path, null);
+        return  p == null ? loadPropertiesStream(path, null) : p;
     }
 
     /**
-     * <p> Reads jcov property file from specified path </p> <p> Path is firstly
-     * checked as a file and is read only if such file exists and can be read.
-     * If it's not a file, can't be read, doesn't exist or is not a property
-     * file then classpath resource is checked. </p>
+     * <p> Reads jcov property file from specified path </p> <p>
+     * If it can't be read then classpath resource is checked. <p>
      *
      * @param path Path to look for a property file.
      * @return Read properties or null if file was not found neither in file
      * system neither in classpath
      */
-    public static Properties readProperties(String path, Properties p) {
-        if (p == null) {
-            p = new Properties();
+    public static Properties readProperties(String path, Properties properties) {
+        if (properties == null) {
+            properties = new Properties();
         }
-
-        File f = new File(path);
-        if (f.exists() && f.isFile() && f.canRead()) {
-            InputStream in = null;
-            try {
-                in = new FileInputStream(f);
-                p.load(in);
-                resolveProps(p);
-                return p;
-            } catch (IOException ex) {
-                // warning message
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (Exception e) {
-                    }
-                }
-            }
-        }
-
-        InputStream in = JCovSaver.class.getResourceAsStream(path);
-        if (in != null) {
-            try {
-                p.load(in);
-                resolveProps(p);
-                return p;
-            } catch (IOException e) {
-                // warning message
-            } finally {
-                try {
-                    in.close();
-                } catch (Exception e) {
-                }
-            }
-        }
-
-        return p;
+        Properties p = loadPropertiesFile(path, properties);
+        return  properties.equals(p) ? loadPropertiesStream(path, properties) : p;
     }
 
     /**
@@ -431,9 +371,7 @@ public final class PropertyFinder {
      */
     private static void resolveProps(Properties props) {
         Pattern p = Pattern.compile(".*(\\$\\{(.*)\\})");
-        Iterator it = props.keySet().iterator();
-        while (it.hasNext()) {
-            Object o = it.next();
+        for (Object o : props.keySet()) {
             String name = (String) o;
             String val = props.getProperty(name);
             Matcher m = p.matcher(val);
@@ -456,7 +394,7 @@ public final class PropertyFinder {
      * property file doesn't exist
      */
     public static String readPropFrom(String fileName, String name) {
-        Properties props = readProperties(fileName, null);
+        Properties props = readProperties(fileName);
         if (props != null) {
             return props.getProperty(PROPERTY_FILE_PREFIX + name);
         } else {
@@ -475,7 +413,7 @@ public final class PropertyFinder {
      * @return String describing property source.
      */
     public static String findSource(String name) {
-        if (name == null || "".equals(name)) {
+        if (name == null || name.isEmpty()) {
             return "";
         }
 
@@ -521,20 +459,22 @@ public final class PropertyFinder {
      * </p>
      */
     public static void addAutoShutdownSave() {
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            public void run() {
-//                System.out.println("JCovRT: autosave fired");
-                if (Collect.saveAtShutdownEnabled && "true".equals(findValue("autosave", "true"))) {
-                    Collect.disable();
-                    Collect.saveResults();
-                    Collect.enable();
-                    Collect.saveAtShutdownEnabled = false;
-                    Collect.saveEnabled = false;
-                }
+        if (Collect.saveAtShutdownEnabled && "true".equals(findValue("autosave", "true"))) {
+            try {
+                Runtime.getRuntime().addShutdownHook(new Thread() {
+                    @Override
+                    public void run() {
+                        Collect.disable();
+                        Collect.saveResults();
+                        Collect.enable();
+                        Collect.saveAtShutdownEnabled = false;
+                        Collect.saveEnabled = false;
+                    }
+                });
+            } catch (Exception ignore) {
+                System.err.println("Can't set shutdown hook.");
             }
-        });
-//        System.out.println("JCovRT: autosave added in: ");
-//        new Exception().printStackTrace();
+        }
     }
 
     /**
@@ -548,7 +488,7 @@ public final class PropertyFinder {
      * properties
      */
     public static boolean isVMReady() {
-
         return System.out != null && Runtime.getRuntime() != null;//&& sun.misc.VM.isBooted();
     }
+
 }


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902535

In JDK 8 Collect.hit method is called prior to the Collect class initialization.  
This causes cyclic throwing NPE.
Also added cosmetic fix to RepGen to avoid double report about internal failures
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902535](https://bugs.openjdk.java.net/browse/CODETOOLS-7902535): Code coverage does not work in JDK 8


### Download
`$ git fetch https://git.openjdk.java.net/jcov pull/1/head:pull/1`
`$ git checkout pull/1`
