### PR TITLE
7902697: Switch jcov to the latest asm lib to support latest classfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# Package Files
+*.jar
+*.zip
+*.tar.gz
+*.tar
+
+# virtual machine crash logs
+hs_err_pid*
+
+# Misc: Intellij Idea,Mac OS
+/.idea/
+*.iml
+.DS_Store
+
+# build
+JCOV_BUILD/
+

--- a/build/build.properties
+++ b/build/build.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,14 @@
 # questions.
 
 # sha1 checksum for asm libraries
-asm.checksum = d74d4ba0dee443f68fb2dcb7fcdb945a2cd89912
-asm.tree.checksum = 29bc62dcb85573af6e62e5b2d735ef65966c4180
-asm.util.checksum = 18d4d07010c24405129a6dbb0e92057f8779fb9d
+asm.checksum = 3f5199523fb95304b44563f5d56d9f5a07270669
+asm.tree.checksum = dfcad5abbcff36f8bdad5647fe6f4972e958ad59
+asm.util.checksum = a8f978fbad00c565210bebedb28e5d6f73327134
 
 # path to asm libraries
-asm.jar = asm-7.0.jar
-asm.tree.jar = asm-tree-7.0.jar
-asm.util.jar = asm-util-7.0.jar
+asm.jar = asm-8.0.1.jar
+asm.tree.jar = asm-tree-8.0.1.jar
+asm.util.jar = asm-util-8.0.1.jar
 
 # path to javatest library (empty value allowed if you do not need jtobserver.jar)
 javatestjar = javatest.jar

--- a/build/build.xml
+++ b/build/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
   This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,7 @@
         <mkdir dir="${jcov.src.update}/com/sun/tdk/jcov/tools"/>
         <echo file="${jcov.src.update}/com/sun/tdk/jcov/tools/JcovVersion.java">
             /*
-            * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+            * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
             * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
             *
             * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@
             public static final String jcovBuildNumber = "${build.number}";
             public static final String jcovBuildDate = "${date}";
             public static String getJcovVersion() {
-                return String.format("%s%s-%s built: %s", jcovVersion, jcovMilestone, jcovBuildNumber, jcovBuildDate);
+                return String.format(" %s_%s (%s) %s", jcovVersion, jcovBuildNumber, jcovMilestone, jcovBuildDate);
               }
             }
         </echo>
@@ -162,13 +162,13 @@
     <target name="compile"  depends="prepare, build-date"
             description="compile main tools">
 
-        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="1.7" source="1.7"
+        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${jcov.src.update}"
                destdir="${jcov.classes}"
                classpath="${jcov.classpath}">
         </javac>
 
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="1.7" source="1.7"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${src.dir}"
                destdir="${jcov.classes}"
                classpath="${jcov.classpath}">
@@ -234,7 +234,7 @@
                 </filterreader>
             </filterchain>
         </copy>
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="1.7" source="1.7"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${jcov.filesaver.src}"
                sourcepath=""
                classpath="${jcov.filesaver.classes}"
@@ -268,7 +268,7 @@
                 </filterreader>
             </filterchain>
         </copy>
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="1.7" source="1.7"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${jcov.networksaver.src}"
                sourcepath=""
                classpath="${jcov.networksaver.classes}"
@@ -285,7 +285,7 @@
 
     <target name="build-jt.observer" depends="prepare" if ="javatest.present" description="build jtobserver jar">
         <mkdir dir="${jcov.jtobserver.classes}"/>
-        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="1.7" source="1.7"
+        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${src.dir}"
                sourcepath=""
                destdir="${jcov.jtobserver.classes}" classpath="${javatestjar}">
@@ -301,7 +301,7 @@
 
     <target name="test" depends="build-jcov">
         <mkdir dir="${result.dir}/test/classes" />
-        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="1.8" source="1.8"
+        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="8" source="8"
                srcdir="${test.src.dir}"
                sourcepath="${test.src.dir}"
                classpath="${testngjar}:${build.dir}/jcov.jar"

--- a/build/release.properties
+++ b/build/release.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,5 +22,6 @@
 # questions.
 
 build.version = 3.0
-build.milestone = os.beta
-build.number = 2
+build.milestone = os.ea
+build.number = 3
+


### PR DESCRIPTION
This is the fix for the issue https://bugs.openjdk.java.net/browse/CODETOOLS-7902697
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902697](https://bugs.openjdk.java.net/browse/CODETOOLS-7902697): Switch jcov to the latest asm lib to support latest classfile


### Download
`$ git fetch https://git.openjdk.java.net/jcov pull/2/head:pull/2`
`$ git checkout pull/2`
