### PR TITLE
7903020: Command line error: Incorrect output filename  - can't write

### DIFF
--- a/src/classes/com/sun/tdk/jcov/Merger.java
+++ b/src/classes/com/sun/tdk/jcov/Merger.java
@@ -961,7 +961,8 @@ public class Merger extends JCovCMDTool {
                     end = Integer.parseInt(rest.substring(second_ind + 1, rest.length()));
                 }
             }
-            Utils.checkFileNotNull(file, "filelist filename", Utils.CheckOptions.FILE_EXISTS, Utils.CheckOptions.FILE_CANREAD, Utils.CheckOptions.FILE_ISFILE);
+            Utils.checkFileNotNull(file, "filelist filename",
+                    Utils.CheckOptions.FILE_EXISTS, Utils.CheckOptions.FILE_CANREAD, Utils.CheckOptions.FILE_ISFILE);
             try {
                 srcs = Utils.readLines(file, start, end);
             } catch (IOException ex) {
@@ -992,7 +993,8 @@ public class Merger extends JCovCMDTool {
         outTestList = null;
         if (opts.isSet(DSC_OUTPUT_TEST_LIST)) {
             outTestList = opts.getValue(DSC_OUTPUT_TEST_LIST);
-            Utils.checkFileNotNull(outTestList, "output testlist filename", Utils.CheckOptions.FILE_CANWRITE, Utils.CheckOptions.FILE_NOTISDIR, Utils.CheckOptions.FILE_PARENTEXISTS);
+            Utils.checkFileNotNull(outTestList, "output testlist filename",
+                    Utils.CheckOptions.FILE_CANWRITE, Utils.CheckOptions.FILE_NOTISDIR, Utils.CheckOptions.FILE_PARENTEXISTS);
             read_scales = true;
         }
         skippedPath = opts.getValue(DSC_SKIPPED);
@@ -1011,12 +1013,14 @@ public class Merger extends JCovCMDTool {
         }
 
         template = opts.getValue(DSC_TEMPLATE);
-        Utils.checkFileCanBeNull(template, "template filename", Utils.CheckOptions.FILE_EXISTS, Utils.CheckOptions.FILE_ISFILE, Utils.CheckOptions.FILE_CANREAD);
+        Utils.checkFileCanBeNull(template, "template filename",
+                Utils.CheckOptions.FILE_EXISTS, Utils.CheckOptions.FILE_ISFILE, Utils.CheckOptions.FILE_CANREAD);
 
         addMissing = template == null;
 
         output = opts.getValue(DSC_OUTPUT);
-        Utils.checkFileNotNull(output, "output filename", Utils.CheckOptions.FILE_NOTISDIR, Utils.CheckOptions.FILE_CANWRITE, Utils.CheckOptions.FILE_PARENTEXISTS);
+        Utils.checkFileNotNull(output, "output filename",
+                Utils.CheckOptions.FILE_NOTISDIR, Utils.CheckOptions.FILE_PARENTEXISTS, Utils.CheckOptions.FILE_CANWRITE);
 
         compress = opts.isSet(DSC_COMPRESS);
         if (opts.isSet(DSC_VERBOSE)) {

--- a/src/classes/com/sun/tdk/jcov/util/Utils.java
+++ b/src/classes/com/sun/tdk/jcov/util/Utils.java
@@ -38,6 +38,7 @@ import java.net.URLClassLoader;
 import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.logging.Formatter;
@@ -1189,8 +1190,17 @@ public final class Utils {
                     }
                     break;
                 case FILE_CANWRITE:
-                    if (!file.canWrite()) {
+                    if ( file.isFile() ) {
+                        // file exists
+                        if( !file.canWrite() ) {
                         throw new EnvHandlingException("Incorrect " + description + " (" + file.getPath() + ") - can't write");
+                        }
+                    } else {
+                        // a new file
+                        File parentDir = file.getAbsoluteFile().getParentFile();
+                        if ( parentDir == null || !parentDir.isDirectory() || ! Files.isWritable(parentDir.toPath()) ) {
+                            throw new EnvHandlingException("Incorrect " + description + " (" + file.getPath() + ") - can't write");
+                        }
                     }
                     break;
                 case FILE_ISFILE:
@@ -1214,8 +1224,8 @@ public final class Utils {
                     }
                     break;
                 case FILE_PARENTEXISTS:
-                    File p = file.getParentFile();
-                    if (p != null && !p.exists()) {
+                    File parent = file.getAbsoluteFile().getParentFile();
+                    if (parent != null && !parent.exists()) {
                         throw new EnvHandlingException("Incorrect " + description + " (" + file.getPath() + ") - parent directory doesn't exist");
                     }
                     break;


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7903020
The fix extends checking of files as existing as non-existing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903020](https://bugs.openjdk.java.net/browse/CODETOOLS-7903020): Command line error: Incorrect output filename  - can't write


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jcov pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jcov pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jcov/pull/18.diff">https://git.openjdk.java.net/jcov/pull/18.diff</a>

</details>
