### PR TITLE
CODETOOLS-7903276: Remove references to ASM from reporting code

### DIFF
--- a/src/classes/com/sun/tdk/jcov/Grabber.java
+++ b/src/classes/com/sun/tdk/jcov/Grabber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@ import com.sun.tdk.jcov.tools.OptionDescr;
 import com.sun.tdk.jcov.util.RuntimeUtils;
 import com.sun.tdk.jcov.util.Utils;
 import com.sun.tdk.jcov.util.Utils.Pair;
-import org.objectweb.asm.Opcodes;
 
 import java.io.*;
 import java.net.*;
@@ -356,7 +355,7 @@ class Server extends Thread {
      * receives data from there
      * @param template template file
      * @param host host to connect in 'once' mode
-     * @param saveAtReceive true = save data when it's coming from Client
+     * @param saveAtRecieve true = save data when it's coming from Client
      * @param genscale allows to generate scales without outtestlist
      * @throws BindException
      * @throws IOException
@@ -696,7 +695,7 @@ class Server extends Thread {
      * Server stores clients data and merges it in memory. Real saving will
      * occur as saveData() method calls. Sets dataSaved to false
      *
-     * @param data received clients data to handle
+     * @param root received clients data to handle
      * @param client client received the data (used for logging)
      * @see #saveData()
      */
@@ -830,7 +829,7 @@ class Server extends Thread {
                         for (DataPackage dp : dataRoot.getPackages()) {
                             for (DataClass dc : dp.getClasses()) {
                                 for (DataMethod dm : dc.getMethods()) {
-                                    if ((dm.isAbstract() || (dm.getAccess() & Opcodes.ACC_NATIVE) != 0)
+                                    if ((dm.getModifiers().isAbstract() || dm.getModifiers().isNative())
                                             && data.length > dm.getSlot() && dm.getCount() < data[dm.getSlot()]) {
                                         dm.setCount(data[dm.getSlot()]);
                                     }

--- a/src/classes/com/sun/tdk/jcov/JREInstr.java
+++ b/src/classes/com/sun/tdk/jcov/JREInstr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 package com.sun.tdk.jcov;
 
+import com.sun.tdk.jcov.instrument.ASMUtils;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions;
 import com.sun.tdk.jcov.instrument.OverriddenClassWriter;
 import com.sun.tdk.jcov.runtime.JCovSESocketSaver;
@@ -274,7 +275,7 @@ public class JREInstr extends JCovCMDTool {
     private void addJCovRuntimeToJavaBase(File file, ClassLoader cl) {
         try {
             updateModuleInfoFile(file, cl, classWriter ->
-                    new ClassVisitor(Utils.ASM_API_VERSION, classWriter) {
+                    new ClassVisitor(ASMUtils.ASM_API_VERSION, classWriter) {
                         @Override
                         public ModuleVisitor visitModule(String name, int access, String version) {
                             ModuleVisitor mv = super.visitModule(name, access, version);
@@ -305,7 +306,7 @@ public class JREInstr extends JCovCMDTool {
     private void updateHashes(File file, ClassLoader cl) {
         try {
             updateModuleInfoFile(file, cl, classWriter ->
-                    new ClassVisitor(Utils.ASM_API_VERSION, classWriter) {
+                    new ClassVisitor(ASMUtils.ASM_API_VERSION, classWriter) {
                         @Override
                         public void visitAttribute(final Attribute attribute) {
                             if (!attribute.type.equals("ModuleHashes")) {

--- a/src/classes/com/sun/tdk/jcov/RepGen.java
+++ b/src/classes/com/sun/tdk/jcov/RepGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ import static com.sun.tdk.jcov.tools.OptionDescr.*;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import org.objectweb.asm.Opcodes;
 
 /**
  * <p> Report generation. </p>
@@ -819,7 +818,7 @@ public class RepGen extends JCovCMDTool {
             boolean ancMethod;
 
             //Synthetic method (and Bridge method)
-            ancMethod = ((m.getAccess() & Opcodes.ACC_SYNTHETIC) != 0);
+            ancMethod = m.getModifiers().isSynthetic();
 
             //Enum method
             ancMethod = ancMethod

--- a/src/classes/com/sun/tdk/jcov/instrument/ASMUtils.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/ASMUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,40 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.report.ancfilters;
+package com.sun.tdk.jcov.instrument;
 
-import com.sun.tdk.jcov.instrument.DataBlock;
-import com.sun.tdk.jcov.instrument.DataClass;
-import com.sun.tdk.jcov.instrument.DataMethod;
-import com.sun.tdk.jcov.report.AncFilter;
+import org.objectweb.asm.Opcodes;
 
-/**
- * @author Alexey Fedorchenko
- */
-public class DeprecatedANCFilter implements AncFilter {
-
-    @Override
-    public boolean accept(DataClass clz) {
-        return false;
-    }
-
-    @Override
-    public boolean accept(DataClass clz, DataMethod m) {
-
-        if (m.getModifiers().isDeprecated()){
-            return true;
-        }
-
-        return false;
-    }
-
-    @Override
-    public boolean accept(DataMethod m, DataBlock b) {
-        return false;
-    }
-
-    @Override
-    public String getAncReason() {
-        return "Deprecated method filter";
-    }
+public class ASMUtils {
+    /**
+     * The ASM API version that should be used by jcov.
+     */
+    public static final int ASM_API_VERSION = Opcodes.ASM9;
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataModifiers.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataModifiers.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.instrument;
+
+import org.objectweb.asm.Opcodes;
+
+public class DataModifiers implements Modifiers {
+    private final int access;
+
+    public DataModifiers(int access) {
+        this.access = access;
+    }
+
+    public int access() {
+        return access;
+    }
+
+    public boolean is(int flag) {
+        return (access & flag) != 0;
+    }
+
+    @Override
+    public boolean isPublic() {
+        return is(Opcodes.ACC_PUBLIC);
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return is(Opcodes.ACC_PRIVATE);
+    }
+
+    @Override
+    public boolean isProtected() { return is(Opcodes.ACC_PROTECTED); }
+
+    @Override
+    public boolean isAbstract() {
+        return is(Opcodes.ACC_ABSTRACT);
+    }
+
+    @Override
+    public boolean isFinal() {
+        return is(Opcodes.ACC_FINAL);
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return is(Opcodes.ACC_SYNTHETIC);
+    }
+
+    @Override
+    public boolean isStatic() {
+        return is(Opcodes.ACC_STATIC);
+    }
+
+    @Override
+    public boolean isInterface() {
+        return is(Opcodes.ACC_INTERFACE);
+    }
+
+    @Override
+    public boolean isSuper() {
+        return is(Opcodes.ACC_SUPER);
+    }
+
+    @Override
+    public boolean isNative() {
+        return is(Opcodes.ACC_NATIVE);
+    }
+
+    @Override
+    public boolean isDeprecated() { return is(Opcodes.ACC_DEPRECATED); }
+}

--- a/src/classes/com/sun/tdk/jcov/instrument/DeferringMethodClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DeferringMethodClassAdapter.java
@@ -51,7 +51,7 @@ class DeferringMethodClassAdapter extends ClassVisitor {
     private static final Logger logger = Logger.getLogger("com.sun.tdk.jcov");
 
     public DeferringMethodClassAdapter(final ClassVisitor cv, DataClass dataClass, InstrumentationParams params) {
-        super(Utils.ASM_API_VERSION, cv);
+        super(ASMUtils.ASM_API_VERSION, cv);
         this.dataClass = dataClass;
         this.params = params;
     }
@@ -188,7 +188,7 @@ class DeferringMethodClassAdapter extends ClassVisitor {
         if ("<clinit>".equals(methodName) &&
                 !params.isDynamicCollect() &&
                 (dataClass.getPackageName().startsWith("java/lang/"))) {
-            mv = new MethodVisitor(Utils.ASM_API_VERSION, mv) {
+            mv = new MethodVisitor(ASMUtils.ASM_API_VERSION, mv) {
                 public void visitCode() {
                     mv.visitMethodInsn(INVOKESTATIC,
                             "com/sun/tdk/jcov/runtime/Collect", "init", "()V",
@@ -230,7 +230,7 @@ class DeferringMethodClassAdapter extends ClassVisitor {
         if (params.isDataSaveFilterAccept(dataClass.getFullname(), methodName, false)) {
             mv = new SavePointsMethodAdapter(mv, false);
         }
-        mv = new MethodVisitor(Utils.ASM_API_VERSION, mv) {
+        mv = new MethodVisitor(ASMUtils.ASM_API_VERSION, mv) {
             @Override
             public void visitLocalVariable(String arg0, String arg1, String arg2, Label arg3, Label arg4, int arg5) {
                 //super.visitLocalVariable(arg0, arg1, arg2, arg3, arg4, arg5);

--- a/src/classes/com/sun/tdk/jcov/instrument/EntryCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/EntryCodeMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ class EntryCodeMethodAdapter extends MethodVisitor {
     EntryCodeMethodAdapter(final MethodVisitor mv,
             final DataMethodEntryOnly method,
             final InstrumentationParams params) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.method = method;
         this.params = params;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/FieldAnnotationVisitor.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/FieldAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ class FieldAnnotationVisitor extends FieldVisitor {
     final FieldVisitor fv;
 
     FieldAnnotationVisitor(final FieldVisitor fv, final DataField field) {
-        super(Utils.ASM_API_VERSION, fv);
+        super(ASMUtils.ASM_API_VERSION, fv);
         this.fv = fv;
         this.field = field;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/ForkingMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/ForkingMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ class ForkingMethodAdapter extends MethodVisitor {
         final AnnotationVisitor av2;
 
         DuplicatingAnnotationAdapter(final AnnotationVisitor av1, final AnnotationVisitor av2) {
-            super(Utils.ASM_API_VERSION);
+            super(ASMUtils.ASM_API_VERSION);
             this.av1 = av1;
             this.av2 = av2;
         }
@@ -89,7 +89,7 @@ class ForkingMethodAdapter extends MethodVisitor {
      * @param mv2 the second code visitor to which this adapter must delegate calls.
      */
     public ForkingMethodAdapter(final MethodVisitor mv1, final MethodVisitor mv2) {
-        super(Utils.ASM_API_VERSION);
+        super(ASMUtils.ASM_API_VERSION);
         this.mv1 = mv1;
         this.mv2 = mv2;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/InstrumentedAttributeClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/InstrumentedAttributeClassAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class InstrumentedAttributeClassAdapter extends ClassVisitor {
     }
 
     public InstrumentedAttributeClassAdapter(final ClassVisitor cv) {
-        super(Utils.ASM_API_VERSION, cv);
+        super(ASMUtils.ASM_API_VERSION, cv);
     }
 
     public void visitAttribute(Attribute attr) {

--- a/src/classes/com/sun/tdk/jcov/instrument/InvokeClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/InvokeClassAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class InvokeClassAdapter extends ClassVisitor {
     private final InstrumentationParams params;
 
     public InvokeClassAdapter(final ClassVisitor cv, final InstrumentationParams params) {
-        super(Utils.ASM_API_VERSION, cv);
+        super(ASMUtils.ASM_API_VERSION, cv);
         this.params = params;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/InvokeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/InvokeMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class InvokeMethodAdapter extends MethodVisitor {
             Collections.synchronizedMap(new HashMap<String, Integer>());
 
     public InvokeMethodAdapter(MethodVisitor mv, String className, final InstrumentationParams params) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.className = className;
         this.params = params;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/MethodAnnotationAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/MethodAnnotationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ class MethodAnnotationAdapter extends MethodVisitor {
 
     MethodAnnotationAdapter(final MethodVisitor mv,
             final DataMethod method) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.meth = method;
     }
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/Modifiers.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/Modifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,40 +22,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.report.ancfilters;
+package com.sun.tdk.jcov.instrument;
 
-import com.sun.tdk.jcov.instrument.DataBlock;
-import com.sun.tdk.jcov.instrument.DataClass;
-import com.sun.tdk.jcov.instrument.DataMethod;
-import com.sun.tdk.jcov.report.AncFilter;
+public interface Modifiers {
+    boolean isPublic();
 
-/**
- * @author Alexey Fedorchenko
- */
-public class DeprecatedANCFilter implements AncFilter {
+    boolean isPrivate();
 
-    @Override
-    public boolean accept(DataClass clz) {
-        return false;
-    }
+    boolean isProtected();
 
-    @Override
-    public boolean accept(DataClass clz, DataMethod m) {
+    boolean isAbstract();
 
-        if (m.getModifiers().isDeprecated()){
-            return true;
-        }
+    boolean isFinal();
 
-        return false;
-    }
+    boolean isSynthetic();
 
-    @Override
-    public boolean accept(DataMethod m, DataBlock b) {
-        return false;
-    }
+    boolean isStatic();
 
-    @Override
-    public String getAncReason() {
-        return "Deprecated method filter";
-    }
+    boolean isInterface();
+
+    boolean isSuper();
+
+    boolean isNative();
+
+    boolean isDeprecated();
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/OffsetRecordingMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/OffsetRecordingMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ class OffsetRecordingMethodAdapter extends MethodVisitor {
 
     public OffsetRecordingMethodAdapter(final MethodVisitor mv,
             final DataMethodWithBlocks method) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.currentInstructionIndex = 0;
         this.bcis = new int[60];
         this.method = method;

--- a/src/classes/com/sun/tdk/jcov/instrument/SavePointsMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/SavePointsMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class SavePointsMethodAdapter extends MethodVisitor {
     private final boolean isBegin;
 
     public SavePointsMethodAdapter(final MethodVisitor mv, boolean isBegin) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.isBegin = isBegin;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/StaticInvokeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/StaticInvokeMethodAdapter.java
@@ -72,7 +72,7 @@ public class StaticInvokeMethodAdapter extends MethodVisitor {
     public StaticInvokeMethodAdapter(MethodVisitor mv, String className,
                                      String methName, int methAccess,
                                      final InstrumentationParams params) {
-        super(Utils.ASM_API_VERSION, mv);
+        super(ASMUtils.ASM_API_VERSION, mv);
         this.className = className;
         this.methName = methName;
         this.methAccess = methAccess;

--- a/src/classes/com/sun/tdk/jcov/report/FieldCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/FieldCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,13 +47,14 @@ public class FieldCoverage extends MemberCoverage {
      * @param fld
      */
     public FieldCoverage(DataField fld) {
-        count = fld.getCount();
-        startLine = 0;
-        modifiers = Arrays.deepToString(fld.getAccessFlags());
-        name = fld.getName();
-        signature = fld.getSignature();
-        scale = fld.getScale();
         access = fld.getAccess();
+        modifiersString =  Arrays.deepToString(fld.getAccessFlags());
+        name =  fld.getName();
+        signature = fld.getSignature();
+        startLine = 0;
+        count = fld.getCount();
+        scale = fld.getScale();
+        modifiers = fld.getModifiers();
     }
 
     /**

--- a/src/classes/com/sun/tdk/jcov/report/MemberCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/MemberCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,11 @@
 package com.sun.tdk.jcov.report;
 
 import com.sun.tdk.jcov.data.Scale;
+import com.sun.tdk.jcov.instrument.Modifiers;
 import com.sun.tdk.jcov.util.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.objectweb.asm.Opcodes;
 
 /**
  * Base class for Method and Field Coverage.
@@ -42,9 +42,10 @@ public abstract class MemberCoverage extends AbstractCoverage {
     protected int startLine;
     protected String name;
     protected String signature;
-    protected String modifiers;
+    protected String modifiersString;
     protected int access;
     protected Scale scale;
+    protected Modifiers modifiers;
 
     /**
      * @return hit count.
@@ -86,8 +87,8 @@ public abstract class MemberCoverage extends AbstractCoverage {
     /**
      * @return String-encoded modifiers
      */
-    public String getModifiers() {
-        return modifiers;
+    public String getModifiersString() {
+        return modifiersString;
     }
 
     /**
@@ -156,7 +157,7 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isPublicAPI() {
-        return (access & (Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED)) != 0;
+        return modifiers.isPublic() || modifiers.isProtected();
     }
 
     /**
@@ -168,7 +169,7 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isPublic() {
-        return (access & Opcodes.ACC_PUBLIC) != 0;
+        return modifiers.isPublic();
     }
 
     /**
@@ -180,7 +181,7 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isPrivate() {
-        return (access & Opcodes.ACC_PRIVATE) != 0;
+        return modifiers.isPrivate();
     }
 
     /**
@@ -192,7 +193,7 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isProtected() {
-        return (access & Opcodes.ACC_PROTECTED) != 0;
+        return modifiers.isProtected();
     }
 
     /**
@@ -204,7 +205,7 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isAbstract() {
-        return (access & Opcodes.ACC_ABSTRACT) != 0;
+        return modifiers.isAbstract();
     }
 
     /**
@@ -216,14 +217,13 @@ public abstract class MemberCoverage extends AbstractCoverage {
      * @see ClassCoverage#getAccess()
      */
     public boolean isFinal() {
-        return (access & Opcodes.ACC_FINAL) != 0;
+        return modifiers.isFinal();
     }
 
     /**
      * <p> Use this method to check for specific modifiers. </p>
      *
      * @return Access bit-mask of org.objectweb.asm.Opcodes constants.
-     * @see Opcodes
      */
     public int getAccess() {
         return access;

--- a/src/classes/com/sun/tdk/jcov/report/ancfilters/SyntheticANCFilter.java
+++ b/src/classes/com/sun/tdk/jcov/report/ancfilters/SyntheticANCFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import com.sun.tdk.jcov.instrument.DataBlock;
 import com.sun.tdk.jcov.instrument.DataClass;
 import com.sun.tdk.jcov.instrument.DataMethod;
 import com.sun.tdk.jcov.report.AncFilter;
-import org.objectweb.asm.Opcodes;
 
 /**
  * @author Alexey Fedorchenko
@@ -43,7 +42,7 @@ public class SyntheticANCFilter implements AncFilter {
     @Override
     public boolean accept(DataClass clz, DataMethod m) {
 
-        if ((m.getAccess() & Opcodes.ACC_SYNTHETIC) != 0){
+        if (m.getModifiers().isSynthetic()){
             return true;
         }
 

--- a/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
+++ b/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1582,7 +1582,7 @@ public class CoverageReport implements ReportGenerator {
                 pw.println(" <td class=\"reportText\"><span class=\"text\">" + mname
                         + "</span></td>");
             }
-            String mmodifiers = mcov.getModifiers();
+            String mmodifiers = mcov.getModifiersString();
             pw.println(" <td class=\"reportText\"><span class=\"text\">" + mmodifiers
                     + "</span></td>");
             pw.println(" <td class=\"reportText\"><span class=\"text\">"

--- a/src/classes/com/sun/tdk/jcov/util/Utils.java
+++ b/src/classes/com/sun/tdk/jcov/util/Utils.java
@@ -27,7 +27,6 @@ package com.sun.tdk.jcov.util;
 import com.sun.tdk.jcov.runtime.PropertyFinder;
 import com.sun.tdk.jcov.tools.JCovTool.EnvHandlingException;
 import com.sun.tdk.jcov.tools.LoggingFormatter;
-import org.objectweb.asm.Opcodes;
 
 import java.io.*;
 import java.lang.reflect.Array;
@@ -56,11 +55,6 @@ import static java.lang.String.format;
  * This class implements miscellaneous utilities, necessary for Jcov
  */
 public final class Utils {
-
-    /**
-     * The ASM API version that should be used by jcov.
-     */
-    public static final int ASM_API_VERSION = Opcodes.ASM9;
 
     private static Handler loggerHandler = null;
     private final static int ASCII_CHARS_TOTAL = 128;


### PR DESCRIPTION
This is part of the cleanup to allow pluggable instrumentation in JCov.

Once all usages of ASM are within the instrument package, we will have to think of the SPI for the instrumentation plugin.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903276](https://bugs.openjdk.org/browse/CODETOOLS-7903276): Remove references to ASM from reporting code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/jcov pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/21.diff">https://git.openjdk.org/jcov/pull/21.diff</a>

</details>
