### PR TITLE
CODETOOLS-7903306: Number format exception while loading the data

### DIFF
--- a/src/classes/com/sun/tdk/jcov/instrument/DataField.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataField.java
@@ -386,7 +386,7 @@ public class DataField extends DataAnnotated implements Comparable<DataField>,
         ctx.attrNormalized(XmlNames.NAME, name);
         ctx.attr(XmlNames.VMSIG, vmSig);
         xmlAccessFlags(ctx, access.access());
-        ctx.attr(XmlNames.ACCESS, access);
+        ctx.attr(XmlNames.ACCESS, access.access());
         ctx.attr(XmlNames.ID, block.getId());
 
         if (value != null) {

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
@@ -434,7 +434,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
         ctx.attr(XmlNames.VMSIG, vmSig);
 
         xmlAccessFlags(ctx, access.access());
-        ctx.attr(XmlNames.ACCESS, access);
+        ctx.attr(XmlNames.ACCESS, access.access());
 
         if (!differentiateMethods) {
             if (name.equals("<init>")) {

--- a/test/unit/com/sun/tdk/jcov/instrument/jreinstr/Code.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/jreinstr/Code.java
@@ -24,8 +24,11 @@
  */
 package com.sun.tdk.jcov.instrument.jreinstr;
 
+import java.util.Random;
+
 public class Code {
     public static void main(String[] args) {
+        new Random().nextInt();
         System.out.println("User code has been executed.");
     }
 }


### PR DESCRIPTION
CODETOOLS-7903306: Number format exception while loading the data

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903306](https://bugs.openjdk.org/browse/CODETOOLS-7903306): Number format exception while loading the data


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/jcov pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/23.diff">https://git.openjdk.org/jcov/pull/23.diff</a>

</details>
