### PR TITLE
CODETOOLS-7903307: Move ASM dependent classes to a different package

### DIFF
--- a/src/classes/com/sun/tdk/jcov/Agent.java
+++ b/src/classes/com/sun/tdk/jcov/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package com.sun.tdk.jcov;
 
 import com.sun.tdk.jcov.constants.MiscConstants;
 import com.sun.tdk.jcov.instrument.*;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph;
 import com.sun.tdk.jcov.runtime.AgentSocketSaver;
 import com.sun.tdk.jcov.runtime.Collect;
 import com.sun.tdk.jcov.runtime.CollectDetect;

--- a/src/classes/com/sun/tdk/jcov/Instr.java
+++ b/src/classes/com/sun/tdk/jcov/Instr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 package com.sun.tdk.jcov;
 
 import com.sun.tdk.jcov.insert.AbstractUniversalInstrumenter;
-import com.sun.tdk.jcov.instrument.ClassMorph;
 import com.sun.tdk.jcov.instrument.InstrumentationParams;
-import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import com.sun.tdk.jcov.tools.EnvHandler;
 import com.sun.tdk.jcov.tools.JCovCMDTool;
 import com.sun.tdk.jcov.tools.OptionDescr;

--- a/src/classes/com/sun/tdk/jcov/Instr2.java
+++ b/src/classes/com/sun/tdk/jcov/Instr2.java
@@ -25,8 +25,8 @@
 package com.sun.tdk.jcov;
 
 import com.sun.tdk.jcov.insert.AbstractUniversalInstrumenter;
-import com.sun.tdk.jcov.instrument.ClassMorph;
-import com.sun.tdk.jcov.instrument.ClassMorph2;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph2;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions;
 import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.tools.EnvHandler;

--- a/src/classes/com/sun/tdk/jcov/ProductInstr.java
+++ b/src/classes/com/sun/tdk/jcov/ProductInstr.java
@@ -26,7 +26,7 @@ package com.sun.tdk.jcov;
 
 import com.sun.tdk.jcov.constants.MiscConstants;
 import com.sun.tdk.jcov.insert.AbstractUniversalInstrumenter;
-import com.sun.tdk.jcov.instrument.ClassMorph;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions;
 import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.tools.EnvHandler;

--- a/src/classes/com/sun/tdk/jcov/TmplGen.java
+++ b/src/classes/com/sun/tdk/jcov/TmplGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 package com.sun.tdk.jcov;
 
 import com.sun.tdk.jcov.insert.AbstractUniversalInstrumenter;
-import com.sun.tdk.jcov.instrument.ClassMorph;
+import com.sun.tdk.jcov.instrument.asm.ClassMorph;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions.InstrumentationMode;
 import com.sun.tdk.jcov.instrument.InstrumentationParams;

--- a/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
+++ b/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
@@ -24,7 +24,7 @@
  */
 package com.sun.tdk.jcov.insert;
 
-import com.sun.tdk.jcov.instrument.OverriddenClassWriter;
+import com.sun.tdk.jcov.instrument.asm.OverriddenClassWriter;
 import com.sun.tdk.jcov.util.Utils;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;

--- a/src/classes/com/sun/tdk/jcov/instrument/BasicBlock.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/BasicBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class BasicBlock extends LocationConcrete {
     /**
      * Creates a new instance of BasicBlock
      */
-    BasicBlock(int rootId, int startBCI) {
+    public BasicBlock(int rootId, int startBCI) {
         super(rootId, startBCI);
         blockMap = new IdentityHashMap<DataBlock, LabelNode>();
     }
@@ -76,7 +76,7 @@ public class BasicBlock extends LocationConcrete {
         this(rootId, -1);
     }
 
-    void add(DataBlock blk, LabelNode label) {
+    public void add(DataBlock blk, LabelNode label) {
         blockMap.put(blk, label);
         if (blk.isFallenInto()) {
             fallenInto = blk;
@@ -88,7 +88,7 @@ public class BasicBlock extends LocationConcrete {
         add(blk, null);
     }
 
-    LabelNode getLabel(DataBlock blk) {
+    public LabelNode getLabel(DataBlock blk) {
         return blockMap.get(blk);
     }
 
@@ -96,7 +96,7 @@ public class BasicBlock extends LocationConcrete {
         return blockMap.containsKey(blk);
     }
 
-    DataBlock fallenInto() {
+    public DataBlock fallenInto() {
         return fallenInto;
     }
 
@@ -104,11 +104,11 @@ public class BasicBlock extends LocationConcrete {
         this.exit = exit;
     }
 
-    Collection<DataBlock> blocks() {
+    public Collection<DataBlock> blocks() {
         return blockMap.keySet();
     }
 
-    Set<Map.Entry<DataBlock, LabelNode>> blockLabelSet() {
+    public Set<Map.Entry<DataBlock, LabelNode>> blockLabelSet() {
         return blockMap.entrySet();
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/Constants.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ package com.sun.tdk.jcov.instrument;
  */
 public class Constants {
 
-    static final String opcNames[] = {
+    public static final String[] opcNames = {
         "nop",
         "aconst_null",
         "iconst_m1",

--- a/src/classes/com/sun/tdk/jcov/instrument/DataAbstract.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataAbstract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public abstract class DataAbstract {
         public int end;
     }
 
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         xmlTagOpen(ctx, kind());
         ctx.incIndent();
         xmlBody(ctx);

--- a/src/classes/com/sun/tdk/jcov/instrument/DataAnnotated.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataAnnotated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public abstract class DataAnnotated extends DataAbstract {
      *
      * @param anno
      */
-    void addAnnotation(String anno) {
+    public void addAnnotation(String anno) {
         if (annotations == null) {
             annotations = new ArrayList<String>();
         }
@@ -57,7 +57,7 @@ public abstract class DataAnnotated extends DataAbstract {
         return annotations != null && annotations.contains(anno);
     }
 
-    protected List<String> getAnnotations() {
+    public List<String> getAnnotations() {
         return annotations;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlock.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,7 +162,7 @@ public abstract class DataBlock extends LocationRef {
      * Does the previous block fall into this one? Override for blocks that are
      * fallen into.
      */
-    boolean isFallenInto() {
+    public boolean isFallenInto() {
         return false;
     }
 
@@ -170,7 +170,7 @@ public abstract class DataBlock extends LocationRef {
      * XML Generation
      */
     @Override
-    void xmlAttrs(XmlContext ctx) {
+    protected void xmlAttrs(XmlContext ctx) {
         super.xmlAttrs(ctx);
         ctx.attr(XmlNames.ID, getId());
         ctx.attr(XmlNames.COUNT, getCount());
@@ -198,7 +198,7 @@ public abstract class DataBlock extends LocationRef {
     }
 
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         xmlGenBodiless(ctx);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockCatch.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockCatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class DataBlockCatch extends DataBlock {
     /**
      * Creates a new instance of DataBlockCatch
      */
-    DataBlockCatch(int rootId) {
+    public DataBlockCatch(int rootId) {
         super(rootId);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockFallThrough.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockFallThrough.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.io.IOException;
  */
 public class DataBlockFallThrough extends DataBlock {
 
-    DataBlockFallThrough(int rootId) {
+    public DataBlockFallThrough(int rootId) {
         super(rootId);
     }
 
@@ -46,7 +46,7 @@ public class DataBlockFallThrough extends DataBlock {
      * Does the previous block fall into this one?
      */
     @Override
-    boolean isFallenInto() {
+    public boolean isFallenInto() {
         return true;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockMethEnter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockMethEnter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.io.IOException;
  */
 public class DataBlockMethEnter extends DataBlock {
 
-    DataBlockMethEnter(int rootId) {
+    public DataBlockMethEnter(int rootId) {
         super(rootId);
     }
 
@@ -47,7 +47,7 @@ public class DataBlockMethEnter extends DataBlock {
      * the first block.
      */
     @Override
-    boolean isFallenInto() {
+    public boolean isFallenInto() {
         return true;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockTarget.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public abstract class DataBlockTarget extends DataBlock {
     }
 
     @Override
-    void xmlAttrs(XmlContext ctx) {
+    protected void xmlAttrs(XmlContext ctx) {
         super.xmlAttrs(ctx);
         xmlAttrsValue(ctx);
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetCase.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class DataBlockTargetCase extends DataBlockTarget {
     /**
      * Creates a new instance of DataBlockTargetCase
      */
-    DataBlockTargetCase(int rootId, int value) {
+    public DataBlockTargetCase(int rootId, int value) {
         super(rootId);
         this.targetValue = value;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetCond.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetCond.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class DataBlockTargetCond extends DataBlockTarget {
 
     private final boolean side;
 
-    DataBlockTargetCond(int rootId, boolean side) {
+    public DataBlockTargetCond(int rootId, boolean side) {
         super(rootId);
         this.side = side;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetDefault.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class DataBlockTargetDefault extends DataBlockTarget {
     /**
      * Creates a new instance of DataBlockTargetDefault
      */
-    DataBlockTargetDefault(int rootId) {
+    public DataBlockTargetDefault(int rootId) {
         super(rootId);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetGoto.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBlockTargetGoto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.io.IOException;
  */
 public class DataBlockTargetGoto extends DataBlockTarget {
 
-    DataBlockTargetGoto(int rootId) {
+    public DataBlockTargetGoto(int rootId) {
         super(rootId);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataBranchSwitch.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataBranchSwitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class DataBranchSwitch extends DataBranch {
     /**
      * Creates a new instance of DataBranchSwitch
      */
-    DataBranchSwitch(int rootId, int bciStart, int bciEnd, DataBlockTargetDefault blockDefault) {
+    public DataBranchSwitch(int rootId, int bciStart, int bciEnd, DataBlockTargetDefault blockDefault) {
         this(rootId, bciStart, bciEnd);
         this.blockDefault = blockDefault;
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataClass.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataClass.java
@@ -601,7 +601,7 @@ public class DataClass extends DataAnnotated implements Comparable<DataClass> {
      * XML Generation. Not supposed to use outside.
      */
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
 
         if ((!ctx.skipNotCoveredClasses || wasHit() && methods.size() > 0)) {
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataExitSimple.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataExitSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,12 +59,12 @@ public class DataExitSimple extends DataExit {
     }
 
     @Override
-    void xmlGen(XmlContext cxt) {
+    public void xmlGen(XmlContext cxt) {
         xmlGenBodiless(cxt);
     }
 
     @Override
-    void xmlAttrs(XmlContext ctx) {
+    protected void xmlAttrs(XmlContext ctx) {
         super.xmlAttrs(ctx);
         ctx.attr(XmlNames.OPCODE, opcodeName());
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataField.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataField.java
@@ -24,6 +24,7 @@
  */
 package com.sun.tdk.jcov.instrument;
 
+import com.sun.tdk.jcov.instrument.asm.InvokeMethodAdapter;
 import com.sun.tdk.jcov.util.NaturalComparator;
 import com.sun.tdk.jcov.data.Scale;
 import com.sun.tdk.jcov.data.ScaleOptions;
@@ -370,7 +371,7 @@ public class DataField extends DataAnnotated implements Comparable<DataField>,
      * XML Generation. Not supposed to use outside.
      */
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         super.xmlGenBodiless(ctx);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
@@ -419,7 +419,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
      * XML Generation. Not supposed to use outside.
      */
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         if (ctx.showAbstract || !access.isAbstract()) {
             super.xmlGen(ctx);
         }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethodEntryOnly.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethodEntryOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ public class DataMethodEntryOnly extends DataMethod implements Iterable<DataBloc
         int slot = (newData) ? Collect.newSlot() : id;
         entryBlock = new DataBlockMethEnter(rootId, slot, newData, 0) {
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);
@@ -136,7 +136,7 @@ public class DataMethodEntryOnly extends DataMethod implements Iterable<DataBloc
         int slot = (newData) ? Collect.newSlot() : id;
         entryBlock = new DataBlockMethEnter(rootId, slot, newData, count) {
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);
@@ -171,7 +171,7 @@ public class DataMethodEntryOnly extends DataMethod implements Iterable<DataBloc
         int slot = (newData) ? Collect.newSlot() : other.getSlot();
         entryBlock = new DataBlockMethEnter(rootId, slot, newData, other.getCount()) {
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);
@@ -249,7 +249,7 @@ public class DataMethodEntryOnly extends DataMethod implements Iterable<DataBloc
 //        }
 //    }
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         super.xmlGenBodiless(ctx);
     }
 
@@ -317,7 +317,7 @@ public class DataMethodEntryOnly extends DataMethod implements Iterable<DataBloc
         super(parent, in);
         entryBlock = new DataBlockMethEnter(parent.rootId, in) {
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethodInvoked.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethodInvoked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package com.sun.tdk.jcov.instrument;
 
 import com.sun.tdk.jcov.data.Scale;
+import com.sun.tdk.jcov.instrument.asm.InvokeMethodAdapter;
 import com.sun.tdk.jcov.runtime.Collect;
 import com.sun.tdk.jcov.runtime.CollectDetect;
 import com.sun.tdk.jcov.tools.OneElemIterator;
@@ -124,7 +125,7 @@ public class DataMethodInvoked extends DataMethod {
             }
 
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);
@@ -188,7 +189,7 @@ public class DataMethodInvoked extends DataMethod {
     }
 
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         super.xmlGenBodiless(ctx);
     }
 
@@ -275,7 +276,7 @@ public class DataMethodInvoked extends DataMethod {
             }
 
             @Override
-            void xmlAttrs(XmlContext ctx) {
+            protected void xmlAttrs(XmlContext ctx) {
                 ctx.attr(XmlNames.ID, getId());
                 ctx.attr(XmlNames.COUNT, getCount());
                 printScale(ctx);

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethodWithBlocks.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethodWithBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package com.sun.tdk.jcov.instrument;
 
 import com.sun.tdk.jcov.data.Scale;
+import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
 import com.sun.tdk.jcov.tools.DelegateIterator;
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/src/classes/com/sun/tdk/jcov/instrument/InstrumentationParams.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/InstrumentationParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package com.sun.tdk.jcov.instrument;
 
 import com.sun.tdk.jcov.instrument.InstrumentationOptions.ABSTRACTMODE;
 import com.sun.tdk.jcov.instrument.InstrumentationOptions.InstrumentationMode;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import com.sun.tdk.jcov.runtime.Collect;
 import com.sun.tdk.jcov.runtime.CollectDetect;
 import com.sun.tdk.jcov.util.Utils;

--- a/src/classes/com/sun/tdk/jcov/instrument/LocationAbstract.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/LocationAbstract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public abstract class LocationAbstract extends DataAbstract implements Comparabl
      * XML Generation
      */
     @Override
-    void xmlAttrs(XmlContext ctx) {
+    protected void xmlAttrs(XmlContext ctx) {
         ctx.attr(XmlNames.START, startBCI());
         ctx.attr(XmlNames.END, endBCI());
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/LocationConcrete.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/LocationConcrete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public abstract class LocationConcrete extends LocationAbstract {
     /**
      * Creates a new instance of LocationAbstract
      */
-    LocationConcrete(int rootId, int startBCI, int endBCI) {
+    protected LocationConcrete(int rootId, int startBCI, int endBCI) {
         super(rootId);
         this.startBCI = startBCI;
         this.endBCI = endBCI;

--- a/src/classes/com/sun/tdk/jcov/instrument/SimpleBasicBlock.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/SimpleBasicBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,7 @@ public class SimpleBasicBlock extends BasicBlock {
     }
 
     @Override
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         block.xmlGen(ctx);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ASMUtils.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ASMUtils.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import org.objectweb.asm.Opcodes;
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
-import com.sun.tdk.jcov.instrument.CharacterRangeTableAttribute.CRTEntry;
 import java.util.*;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import com.sun.tdk.jcov.instrument.DataBlock;
+import com.sun.tdk.jcov.instrument.DataBlockFallThrough;
+import com.sun.tdk.jcov.instrument.DataBlockTargetDefault;
+import com.sun.tdk.jcov.instrument.DataBranchCond;
+import com.sun.tdk.jcov.instrument.DataBranchGoto;
+import com.sun.tdk.jcov.instrument.DataBranchSwitch;
+import com.sun.tdk.jcov.instrument.DataExit;
+import com.sun.tdk.jcov.instrument.DataExitSimple;
+import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
+import com.sun.tdk.jcov.instrument.SimpleBasicBlock;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Attribute;
 
@@ -59,7 +69,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
     private SimpleBasicBlock getBB(AbstractInsnNode insn, int startBCI) {
         SimpleBasicBlock bb = insnToBB.get(insn);
         if (bb == null) {
-            bb = new SimpleBasicBlock(method.rootId, startBCI);
+            bb = new SimpleBasicBlock(method.rootId(), startBCI);
             insnToBB.put(insn, bb);
         } else if (startBCI >= 0) {
             bb.setStartBCI(startBCI);
@@ -137,7 +147,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                         LabelNode insnTrue = jumpInsn.label;
                         int bciFalse = bcis[insnIdx]; // fall-through
 
-                        DataBranchCond branch = new DataBranchCond(method.rootId, bci, bciFalse - 1);
+                        DataBranchCond branch = new DataBranchCond(method.rootId(), bci, bciFalse - 1);
                         /* DataBlockTarget blockTrue = new DataBlockTargetCond(true);
                          DataBlockTarget blockFalse = new DataBlockTargetCond(false);
                          branch.addTarget(blockTrue);
@@ -174,7 +184,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
 
                         // Create the branch information
                         int bciEnd = bcis[insnIdx] - 1; // end of the switch
-                        DataBranchSwitch branch = new DataBranchSwitch(method.rootId, bci, bciEnd, blockDefault);
+                        DataBranchSwitch branch = new DataBranchSwitch(method.rootId(), bci, bciEnd, blockDefault);
                         // branch.addTarget(blockDefault);
                         exits.add(branch);
 
@@ -211,7 +221,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
 
                         // Create the branch information
                         int bciEnd = bcis[insnIdx] - 1; // end of the switch
-                        DataBranchSwitch branch = new DataBranchSwitch(method.rootId, bci, bciEnd, blockDefault);
+                        DataBranchSwitch branch = new DataBranchSwitch(method.rootId(), bci, bciEnd, blockDefault);
                         // branch.addTarget(blockDefault);
                         exits.add(branch);
 
@@ -239,7 +249,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
 
                         // Create origin info, a branch
                         int bciEnd = bcis[insnIdx] - 1;
-                        DataBranchGoto branch = new DataBranchGoto(method.rootId, bci, bciEnd);
+                        DataBranchGoto branch = new DataBranchGoto(method.rootId(), bci, bciEnd);
                         exits.add(branch);
 
                         // Create destination info, a block target
@@ -263,7 +273,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                     case ARETURN:
                     case RETURN: {
                         int bciNext = bcis[insnIdx];
-                        DataExit exit = new DataExitSimple(method.rootId, bci, bciNext - 1, insn.getOpcode());
+                        DataExit exit = new DataExitSimple(method.rootId(), bci, bciNext - 1, insn.getOpcode());
                         exits.add(exit);
 
                         AbstractInsnNode insnNext = peek(iit);
@@ -318,7 +328,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                 for (CharacterRangeTableAttribute.CRTEntry entry : method().getCharacterRangeTable().getEntries()) {
                     if (entry.startBCI() == bci) {
 
-                        if ((entry.flags & CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
+                        if ((entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
                             newBlock = false;
                             if (insnToBB.get(insn) == null) {
                                 //System.out.println("Should add block at: " + bci + " in " + method().name +
@@ -328,7 +338,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                             }
                         }
                     } else {
-                        if (entry.endBCI() == index && (entry.flags & CRTEntry.CRT_FLOW_TARGET) != 0) {
+                        if (entry.endBCI() == index && (entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_FLOW_TARGET) != 0) {
                             newBlock = true;
                         }
                     }

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.data.FileFormatException;
+import com.sun.tdk.jcov.instrument.DataRoot;
+import com.sun.tdk.jcov.instrument.LocationConcrete;
+import com.sun.tdk.jcov.instrument.XmlContext;
+import com.sun.tdk.jcov.instrument.XmlNames;
 import com.sun.tdk.jcov.instrument.reader.Reader;
 import com.sun.tdk.jcov.instrument.reader.ReaderFactory;
 import org.objectweb.asm.Attribute;
@@ -84,7 +88,7 @@ public class CharacterRangeTableAttribute extends Attribute {
             return XmlNames.RANGE;
         }
 
-        void xmlAttrs(XmlContext ctx) {
+        public void xmlAttrs(XmlContext ctx) {
             super.xmlAttrs(ctx);
             if ((flags & CRT_STATEMENT) != 0) {
                 ctx.attr(XmlNames.A_STATEMENT, true);
@@ -216,7 +220,7 @@ public class CharacterRangeTableAttribute extends Attribute {
      * Since there is no multiple inheritance, we aren't a DataAbstract, but
      * we'll fake it
      */
-    void xmlGen(XmlContext ctx) {
+    public void xmlGen(XmlContext ctx) {
         ctx.indent();
         ctx.println("<" + XmlNames.CRT + ">");
         ctx.incIndent();

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
@@ -22,9 +22,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.data.FileFormatException;
+import com.sun.tdk.jcov.instrument.BasicBlock;
+import com.sun.tdk.jcov.instrument.DataBlock;
+import com.sun.tdk.jcov.instrument.DataClass;
+import com.sun.tdk.jcov.instrument.DataField;
+import com.sun.tdk.jcov.instrument.DataMethod;
+import com.sun.tdk.jcov.instrument.DataMethodEntryOnly;
+import com.sun.tdk.jcov.instrument.DataMethodInvoked;
+import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
+import com.sun.tdk.jcov.instrument.DataPackage;
+import com.sun.tdk.jcov.instrument.DataRoot;
+import com.sun.tdk.jcov.instrument.InstrumentationOptions;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
+import com.sun.tdk.jcov.instrument.XmlNames;
 import com.sun.tdk.jcov.io.Reader;
 import com.sun.tdk.jcov.runtime.Collect;
 import com.sun.tdk.jcov.runtime.FileSaver;
@@ -224,7 +237,7 @@ public class ClassMorph {
             }
         }
         if (moduleName == null){
-            moduleName = "module "+XmlNames.NO_MODULE;
+            moduleName = "module "+ XmlNames.NO_MODULE;
         }
 
         if (!params.isModuleIncluded(moduleName.substring(7, moduleName.length()))){

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph2.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataRoot;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.io.Reader;
 import com.sun.tdk.jcov.util.DebugUtils;
 import org.objectweb.asm.*;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/DeferringMethodClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/DeferringMethodClassAdapter.java
@@ -22,8 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataClass;
+import com.sun.tdk.jcov.instrument.DataField;
+import com.sun.tdk.jcov.instrument.DataMethod;
+import com.sun.tdk.jcov.instrument.DataMethodEntryOnly;
+import com.sun.tdk.jcov.instrument.DataMethodInvoked;
+import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
+import com.sun.tdk.jcov.instrument.InstrumentationOptions;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/EntryCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/EntryCodeMethodAdapter.java
@@ -22,8 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataMethodEntryOnly;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Label;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/FieldAnnotationVisitor.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/FieldAnnotationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,40 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
-import org.objectweb.asm.Label;
+import com.sun.tdk.jcov.instrument.DataField;
+import com.sun.tdk.jcov.util.Utils;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.FieldVisitor;
 
 /**
- * OffsetLabel
+ * Field visitor collecting runtime annotations
  *
- * @author Robert Field
+ * @author Dmitry Fazunenko
  */
-class OffsetLabel extends Label {
+class FieldAnnotationVisitor extends FieldVisitor {
 
-    int originalOffset;
-    boolean realLabel;
+    final DataField field;
+    final FieldVisitor fv;
 
-    OffsetLabel(int originalOffset) {
-        this.originalOffset = originalOffset;
+    FieldAnnotationVisitor(final FieldVisitor fv, final DataField field) {
+        super(ASMUtils.ASM_API_VERSION, fv);
+        this.fv = fv;
+        this.field = field;
+    }
+
+    public void visitAttribute(Attribute arg0) {
+        fv.visitAttribute(arg0);
+    }
+
+    public void visitEnd() {
+        fv.visitEnd();
+    }
+
+    public AnnotationVisitor visitAnnotation(String anno, boolean b) {
+        field.addAnnotation(anno);
+        return fv.visitAnnotation(anno, b);
     }
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ForkingMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ForkingMethodAdapter.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.AnnotationVisitor;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/InstrumentationPlugin.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/InstrumentationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import org.objectweb.asm.MethodVisitor;
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/InstrumentedAttributeClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/InstrumentedAttributeClassAdapter.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.Attribute;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/Instrumenter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/Instrumenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataBlock;
+import com.sun.tdk.jcov.instrument.SimpleBasicBlock;
 import org.objectweb.asm.tree.*;
 
 import org.objectweb.asm.MethodVisitor;
@@ -59,11 +61,11 @@ class Instrumenter {
         return il;
     }
 
-    static InsnList instrumentation(DataBlock block, boolean detectInternal) {
+    public static InsnList instrumentation(DataBlock block, boolean detectInternal) {
         return instrumentation(block.getId(), detectInternal);
     }
 
-    static InsnList instrumentation(SimpleBasicBlock block, boolean detectInternal) {
+    public static InsnList instrumentation(SimpleBasicBlock block, boolean detectInternal) {
         return instrumentation(block.getId(), detectInternal);
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/InvokeClassAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/InvokeClassAdapter.java
@@ -22,8 +22,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/InvokeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/InvokeMethodAdapter.java
@@ -22,13 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.InsnList;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/MethodAnnotationAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/MethodAnnotationAdapter.java
@@ -22,39 +22,31 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataMethod;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Attribute;
-import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
- * Field visitor collecting runtime annotations
+ * Class that does nothing but collects runtime annotations
  *
  * @author Dmitry Fazunenko
  */
-class FieldAnnotationVisitor extends FieldVisitor {
+class MethodAnnotationAdapter extends MethodVisitor {
 
-    final DataField field;
-    final FieldVisitor fv;
+    final DataMethod meth;
 
-    FieldAnnotationVisitor(final FieldVisitor fv, final DataField field) {
-        super(ASMUtils.ASM_API_VERSION, fv);
-        this.fv = fv;
-        this.field = field;
-    }
-
-    public void visitAttribute(Attribute arg0) {
-        fv.visitAttribute(arg0);
-    }
-
-    public void visitEnd() {
-        fv.visitEnd();
-    }
-
+    @Override
     public AnnotationVisitor visitAnnotation(String anno, boolean b) {
-        field.addAnnotation(anno);
-        return fv.visitAnnotation(anno, b);
+        meth.addAnnotation(anno);
+        return super.visitAnnotation(anno, b);
+    }
+
+    MethodAnnotationAdapter(final MethodVisitor mv,
+            final DataMethod method) {
+        super(ASMUtils.ASM_API_VERSION, mv);
+        this.meth = method;
     }
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/NativeWrappingMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/NativeWrappingMethodAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataMethodEntryOnly;
+import com.sun.tdk.jcov.instrument.InstrumentationOptions;
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.ClassVisitor;
 
@@ -179,7 +182,8 @@ class NativeWrappingMethodAdapter extends ForkingMethodAdapter {
         } else {
             invokeOp = INVOKESTATIC;
         }
-        instructions.add(new MethodInsnNode(invokeOp, dataMethod.getParent().getFullname(), InstrumentationOptions.nativePrefix + dataMethod.getName(), dataMethod.getVmSignature()));
+        instructions.add(new MethodInsnNode(invokeOp, dataMethod.getParent().getFullname(),
+                InstrumentationOptions.nativePrefix + dataMethod.getName(), dataMethod.getVmSignature()));
 
         // return correct type
         switch (descriptor.charAt(index + 1)) {

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/OffsetLabel.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/OffsetLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,44 +22,21 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
-import java.io.IOException;
-import java.io.InputStream;
-import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Label;
 
 /**
- * OffsetLabelingClassReader
- *
+ * OffsetLabel
  *
  * @author Robert Field
  */
-class OffsetLabelingClassReader extends ClassReader {
+class OffsetLabel extends Label {
 
-    public OffsetLabelingClassReader(byte[] b) {
-        super(b);
-    }
+    int originalOffset;
+    boolean realLabel;
 
-    public OffsetLabelingClassReader(InputStream in) throws IOException {
-        super(in);
-    }
-
-    /**
-     * @Override public void accept(ClassVisitor cv, Attribute[] attrs, int
-     * flags) { super.accept(new MyClassAdapter(cv), attrs, flags); }
-     ***
-     */
-    @Override
-    protected Label readLabel(int offset, Label[] labels) {
-        OffsetLabel label = (OffsetLabel) labels[offset];
-        if (label == null) {
-            for (int i = 0; i < labels.length; ++i) {
-                labels[i] = new OffsetLabel(i);
-            }
-            label = (OffsetLabel) labels[offset];
-        }
-        label.realLabel = true;
-        return label;
+    OffsetLabel(int originalOffset) {
+        this.originalOffset = originalOffset;
     }
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/OffsetRecordingMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/OffsetRecordingMethodAdapter.java
@@ -22,8 +22,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Handle;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/OverriddenClassWriter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/OverriddenClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021,  Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022  Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.JREInstr;
 import com.sun.tdk.jcov.runtime.PropertyFinder;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/SavePointsMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/SavePointsMethodAdapter.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.util.Utils;
 import org.objectweb.asm.MethodVisitor;

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/StaticInvokeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/StaticInvokeMethodAdapter.java
@@ -22,8 +22,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument;
+package com.sun.tdk.jcov.instrument.asm;
 
+import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.util.Utils;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/classes/com/sun/tdk/jcov/instrument/reader/CharacterRangeTableAttributeStAX.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/reader/CharacterRangeTableAttributeStAX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 package com.sun.tdk.jcov.instrument.reader;
 
 import com.sun.tdk.jcov.data.FileFormatException;
-import com.sun.tdk.jcov.instrument.CharacterRangeTableAttribute;
-import com.sun.tdk.jcov.instrument.CharacterRangeTableAttribute.CRTEntry;
+import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
+import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute.CRTEntry;
 import com.sun.tdk.jcov.instrument.XmlNames;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/classes/com/sun/tdk/jcov/instrument/reader/DataMethodWithBlocksStAX.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/reader/DataMethodWithBlocksStAX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package com.sun.tdk.jcov.instrument.reader;
 
 import com.sun.tdk.jcov.data.FileFormatException;
 import com.sun.tdk.jcov.instrument.BasicBlock;
-import com.sun.tdk.jcov.instrument.CharacterRangeTableAttribute;
+import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
 import com.sun.tdk.jcov.instrument.DataAbstract.LocationCoords;
 import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
 import com.sun.tdk.jcov.instrument.DataRoot;

--- a/test/unit/com/sun/tdk/jcov/instrument/plugin/FieldsPlugin.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/plugin/FieldsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
  */
 package com.sun.tdk.jcov.instrument.plugin;
 
-import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import com.sun.tdk.jcov.runtime.JCovSaver;
 import org.objectweb.asm.MethodVisitor;
 

--- a/test/unit/com/sun/tdk/jcov/instrument/plugin/jreinstr/TestPlugin.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/plugin/jreinstr/TestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
  */
 package com.sun.tdk.jcov.instrument.plugin.jreinstr;
 
-import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import org.objectweb.asm.MethodVisitor;
 
 import java.io.IOException;


### PR DESCRIPTION
This change is moving all classes which directly depend on ASM into a sub-package. This is done in a separate step to allow a diff which would be possible to review line by line, to make sure there are no changes in behavior.
To accommodate the move:
1. Bunch of imports, obviously
2. Bunch of methods increased visibility to public, or, in rare cases, to protected
3. A few field usages are replaced with getters.
Further refactoring is due, see the bug for more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903307](https://bugs.openjdk.org/browse/CODETOOLS-7903307): Move ASM dependent classes to a different package


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jcov pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/24.diff">https://git.openjdk.org/jcov/pull/24.diff</a>

</details>
