### PR TITLE
CODETOOLS-7903308: Refactor com.sun.tdk.jcov.instrument.BasicBlock to not depend on ASM

### DIFF
--- a/plugins/data_coverage/src/openjdk/jcov/data/arguments/instrument/Plugin.java
+++ b/plugins/data_coverage/src/openjdk/jcov/data/arguments/instrument/Plugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
  */
 package openjdk.jcov.data.arguments.instrument;
 
-import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import openjdk.jcov.data.arguments.runtime.Collect;
 import openjdk.jcov.data.arguments.runtime.Coverage;
 import openjdk.jcov.data.Env;

--- a/plugins/data_coverage/test/openjdk/jcov/data/arguments/jreinstr/filepermission/VoidPlugin.java
+++ b/plugins/data_coverage/test/openjdk/jcov/data/arguments/jreinstr/filepermission/VoidPlugin.java
@@ -1,6 +1,6 @@
 package openjdk.jcov.data.arguments.jreinstr.filepermission;
 
-import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
+import com.sun.tdk.jcov.instrument.asm.InstrumentationPlugin;
 import org.objectweb.asm.MethodVisitor;
 
 import java.nio.file.Path;

--- a/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
+++ b/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
@@ -190,7 +190,6 @@ public abstract class AbstractUniversalInstrumenter {
             logger.log(Level.SEVERE, "  Error reading data from '" + fname + "' - skipped", e);
             instredFine = false;
         } catch (NullPointerException e) {
-            e.printStackTrace();
             logger.log(Level.SEVERE, "  Error reading data from '" + fname + "' - skipped", e);
             instredFine = false;
         } catch (Exception e) {

--- a/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
+++ b/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
@@ -190,6 +190,7 @@ public abstract class AbstractUniversalInstrumenter {
             logger.log(Level.SEVERE, "  Error reading data from '" + fname + "' - skipped", e);
             instredFine = false;
         } catch (NullPointerException e) {
+            e.printStackTrace();
             logger.log(Level.SEVERE, "  Error reading data from '" + fname + "' - skipped", e);
             instredFine = false;
         } catch (Exception e) {

--- a/src/classes/com/sun/tdk/jcov/instrument/DataRoot.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataRoot.java
@@ -1354,7 +1354,7 @@ public class DataRoot extends DataAbstract {
                     } else {
                         DataMethodWithBlocks mb = (DataMethodWithBlocks) meth;
                         for (BasicBlock bb : mb.getBasicBlocks()) {
-                            for (DataBlock db : bb.blockMap.keySet()) {
+                            for (DataBlock db : bb.blocks()) {
                                 long count = merge ? db.getCount() : 0;
                                 db.setCount(count + counts[db.getId()]);
                             }

--- a/test/unit/com/sun/tdk/jcov/instrument/Util.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/Util.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.instrument;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+public class Util {
+    private final Path outputDir;
+
+    public Util(Path dir) {
+        outputDir = dir;
+    }
+
+    public List<Path> copyBytecode(String... classes) throws IOException {
+        byte[] buf = new byte[1024];
+        List<Path> result = new ArrayList<>();
+        for(String c : classes) {
+            String classFile = classFile(c);
+            try(InputStream in = getClass().getClassLoader().getResourceAsStream(classFile)) {
+                Path o = outputDir.resolve(classFile);
+                result.add(o);
+                if(!Files.exists(o.getParent())) Files.createDirectories(o.getParent());
+                try(OutputStream out = Files.newOutputStream(o)) {
+                    int read;
+                    while((read = in.read(buf)) > 0)
+                        out.write(buf, 0, read);
+                }
+            }
+        };
+        return result;
+    }
+
+    public static Path copyJRE(Path src) throws IOException {
+        Path dest = Files.createTempDirectory("JDK");
+        System.out.println("Copying a JDK from " + src + " to " + dest);
+        Files.walk(src).forEach(s -> {
+            try {
+                Files.copy(s, dest.resolve(src.relativize(s)), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+        return dest;
+    }
+
+    public static Path createRtJar(String prefix, Class collect) throws IOException {
+        Path dest = Files.createTempFile(prefix, ".jar");
+        System.out.println(prefix + " jar: " + dest);
+        try(JarOutputStream jar = new JarOutputStream(Files.newOutputStream(dest))) {
+            jar.putNextEntry(new JarEntry(collect.getName().replace(".", File.separator) + ".class"));
+            try (InputStream ci = collect.getClassLoader()
+                    .getResourceAsStream(collect.getName().replace('.', '/') + ".class")) {
+                byte[] buffer = new byte[1024];
+                int read;
+                while((read = ci.read(buffer)) > 0) {
+                    jar.write(buffer, 0, read);
+                }
+            }
+        }
+        return dest;
+    }
+
+    public static String classFile(String className) {
+        return className.replace('.', '/') + ".class";
+    }
+    public Class runClass(Class className, String[] argv)
+            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        return runClass(className.getName(), argv);
+    }
+    public Class runClass(String className, String[] argv)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InvocationTargetException, IllegalAccessException, InstantiationException {
+        ClassLoader offOutputDir = new InstrumentedClassLoader();
+        Class cls = offOutputDir.loadClass(className);
+        Method m = cls.getMethod("main", new String[0].getClass());
+        m.invoke(null, (Object)argv);
+        return cls;
+    }
+
+    private class InstrumentedClassLoader extends ClassLoader {
+        protected InstrumentedClassLoader() {
+            super(Util.class.getClassLoader());
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            Path classFile = outputDir.resolve(classFile(name));
+            if(Files.exists(classFile)) {
+                byte[] buf = new byte[1024];
+                try(InputStream in = Files.newInputStream(classFile)) {
+                    try(ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                        int read;
+                        while((read = in.read(buf)) > 0)
+                            out.write(buf, 0, read);
+                        return defineClass(name, out.toByteArray(), 0, out.size());
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return super.loadClass(name);
+        }
+    }
+    public static void rmRF(Path jre) throws IOException {
+        System.out.println("Removing " + jre);
+        if(Files.isRegularFile(jre))
+            Files.deleteIfExists(jre);
+        else
+            Files.walkFileTree(jre, new FileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+    }
+}

--- a/test/unit/com/sun/tdk/jcov/instrument/instr/InstrTest.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/instr/InstrTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.instrument.instr;
+
+import com.sun.tdk.jcov.Instr;
+import com.sun.tdk.jcov.data.FileFormatException;
+import com.sun.tdk.jcov.instrument.DataMethod;
+import com.sun.tdk.jcov.instrument.DataRoot;
+import com.sun.tdk.jcov.instrument.Util;
+import com.sun.tdk.jcov.io.Reader;
+import com.sun.tdk.jcov.runtime.Collect;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+public class InstrTest {
+    Path test_dir;
+    Path template;
+    int method_slot = -1;
+    @BeforeClass
+    public void clean() throws IOException {
+        System.setProperty("jcov.selftest", "true");
+        Path data_dir = Paths.get(System.getProperty("user.dir"));
+        test_dir = data_dir.resolve("instr_test");
+        System.out.println("test dir = " + test_dir);
+        Util.rmRF(test_dir);
+        template = test_dir.resolve("template.lst");
+    }
+    @Test
+    public void instrument() throws IOException, InterruptedException, FileFormatException {
+        List<String> params = new ArrayList<>();
+        params.add("-t");
+        params.add(template.toString());
+        params.add(new Util(test_dir).copyBytecode(UserCode.class.getName()).get(0).toString());
+        new Instr().run(params.toArray(new String[0]));
+        DataRoot data = Reader.readXML(template.toString());
+        DataMethod dm =
+                data.getPackages().stream().filter(p -> p.getName().equals("com/sun/tdk/jcov/instrument/instr")).findAny().get()
+                .getClasses().stream().filter(c -> c.getName().equals("UserCode")).findAny().get()
+                .getMethods().stream().filter(m -> m.getName().equals("main")).findAny().get();
+        method_slot = dm.getSlot();
+        assertTrue(method_slot > 0);
+    }
+
+    @Test(dependsOnMethods = "instrument")
+    public void run() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException, IOException, InstantiationException {
+        new Util(test_dir).runClass(UserCode.class, new String[] {"+"});
+        assertTrue(Collect.wasHit(method_slot));
+    }
+
+    @AfterClass
+    public void tearDown() throws IOException {
+        Util.rmRF(test_dir);
+    }
+}

--- a/test/unit/com/sun/tdk/jcov/instrument/instr/UserCode.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/instr/UserCode.java
@@ -22,13 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.tdk.jcov.instrument.jreinstr;
+package com.sun.tdk.jcov.instrument.instr;
 
-import javax.swing.JFrame;
-
-public class Code {
+public class UserCode {
+    private static int count = 0;
     public static void main(String[] args) {
-        new JFrame();
-        System.out.println("User code has been executed.");
+        if(args[0].equals("-")) count--;
+        else if(args[0].equals("+")) count++;
+        System.out.println("User code is running.");
     }
 }


### PR DESCRIPTION
This change removes dependency from BasicBlock to ASM. 

BasicBlock used to keep map from DataBlocks to LabelNodes, which only been used within BranchCodeMethodAdapter. To remove the dependency, a map is added to the BranchCodeMethodAdapter to keep the mapping. BasicBlock is instead keeping data blocks in a set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903308](https://bugs.openjdk.org/browse/CODETOOLS-7903308): Refactor com.sun.tdk.jcov.instrument.BasicBlock to not depend on ASM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jcov pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/25.diff">https://git.openjdk.org/jcov/pull/25.diff</a>

</details>
