### PR TITLE
7903320: Move InvokeMethodAdapter.getInvokeID(String, String, String) up

### DIFF
--- a/src/classes/com/sun/tdk/jcov/instrument/DataAbstract.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataAbstract.java
@@ -31,7 +31,10 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.objectweb.asm.Opcodes.*;
 
@@ -42,6 +45,30 @@ import static org.objectweb.asm.Opcodes.*;
  * @author Robert Field
  */
 public abstract class DataAbstract {
+
+    final private static Map<String, Integer> map =
+            Collections.synchronizedMap(new HashMap<String, Integer>());
+    static volatile int invokeCount = 0;
+
+    public static int getInvokeID(String owner, String name, String descr) {
+        String sig = owner + "." + name + descr;
+        synchronized (map) {
+            Integer id = map.get(sig);
+            if (id != null) {
+                return id;
+            }
+            //return 0;
+            id = invokeCount++;
+            map.put(sig, id);
+            return id;
+        }
+    }
+
+    //never used
+    public static void addID(String className, String name, String descr, int id) {
+        String sig = className + "." + name + descr;
+        map.put(sig, id);
+    }
 
     protected int rootId;
 

--- a/src/classes/com/sun/tdk/jcov/instrument/DataField.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataField.java
@@ -24,7 +24,6 @@
  */
 package com.sun.tdk.jcov.instrument;
 
-import com.sun.tdk.jcov.instrument.asm.InvokeMethodAdapter;
 import com.sun.tdk.jcov.util.NaturalComparator;
 import com.sun.tdk.jcov.data.Scale;
 import com.sun.tdk.jcov.data.ScaleOptions;
@@ -135,17 +134,17 @@ public class DataField extends DataAnnotated implements Comparable<DataField>,
 
             @Override
             protected boolean wasCollectHit() {
-                return CollectDetect.wasInvokeHit(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc));
+                return CollectDetect.wasInvokeHit(DataAbstract.getInvokeID(k.getFullname(), name, desc));
             }
 
             @Override
             protected long collectCount() {
-                return CollectDetect.invokeCountFor(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc));
+                return CollectDetect.invokeCountFor(DataAbstract.getInvokeID(k.getFullname(), name, desc));
             }
 
             @Override
             protected void setCollectCount(long count) {
-                CollectDetect.setInvokeCountFor(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc), count);
+                CollectDetect.setInvokeCountFor(DataAbstract.getInvokeID(k.getFullname(), name, desc), count);
             }
 
         };
@@ -529,17 +528,17 @@ public class DataField extends DataAnnotated implements Comparable<DataField>,
 
             @Override
             protected boolean wasCollectHit() {
-                return CollectDetect.wasInvokeHit(InvokeMethodAdapter.getInvokeID(c.getFullname(), name, vmSig));
+                return CollectDetect.wasInvokeHit(DataAbstract.getInvokeID(c.getFullname(), name, vmSig));
             }
 
             @Override
             protected long collectCount() {
-                return CollectDetect.invokeCountFor(InvokeMethodAdapter.getInvokeID(c.getFullname(), name, vmSig));
+                return CollectDetect.invokeCountFor(DataAbstract.getInvokeID(c.getFullname(), name, vmSig));
             }
 
             @Override
             protected void setCollectCount(long count) {
-                CollectDetect.setInvokeCountFor(InvokeMethodAdapter.getInvokeID(c.getFullname(), name, vmSig), count);
+                CollectDetect.setInvokeCountFor(DataAbstract.getInvokeID(c.getFullname(), name, vmSig), count);
             }
         };
     }

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethodInvoked.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethodInvoked.java
@@ -25,7 +25,6 @@
 package com.sun.tdk.jcov.instrument;
 
 import com.sun.tdk.jcov.data.Scale;
-import com.sun.tdk.jcov.instrument.asm.InvokeMethodAdapter;
 import com.sun.tdk.jcov.runtime.Collect;
 import com.sun.tdk.jcov.runtime.CollectDetect;
 import com.sun.tdk.jcov.tools.OneElemIterator;
@@ -111,17 +110,17 @@ public class DataMethodInvoked extends DataMethod {
 
             @Override
             protected boolean wasCollectHit() {
-                return CollectDetect.wasInvokeHit(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc));
+                return CollectDetect.wasInvokeHit(DataAbstract.getInvokeID(k.getFullname(), name, desc));
             }
 
             @Override
             protected long collectCount() {
-                return CollectDetect.invokeCountFor(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc));
+                return CollectDetect.invokeCountFor(DataAbstract.getInvokeID(k.getFullname(), name, desc));
             }
 
             @Override
             protected void setCollectCount(long count) {
-                CollectDetect.setInvokeCountFor(InvokeMethodAdapter.getInvokeID(k.getFullname(), name, desc), count);
+                CollectDetect.setInvokeCountFor(DataAbstract.getInvokeID(k.getFullname(), name, desc), count);
             }
 
             @Override
@@ -262,17 +261,17 @@ public class DataMethodInvoked extends DataMethod {
 
             @Override
             protected boolean wasCollectHit() {
-                return CollectDetect.wasInvokeHit(InvokeMethodAdapter.getInvokeID(parent.getFullname(), name, vmSig));
+                return CollectDetect.wasInvokeHit(DataAbstract.getInvokeID(parent.getFullname(), name, vmSig));
             }
 
             @Override
             protected long collectCount() {
-                return CollectDetect.invokeCountFor(InvokeMethodAdapter.getInvokeID(parent.getFullname(), name, vmSig));
+                return CollectDetect.invokeCountFor(DataAbstract.getInvokeID(parent.getFullname(), name, vmSig));
             }
 
             @Override
             protected void setCollectCount(long count) {
-                CollectDetect.setInvokeCountFor(InvokeMethodAdapter.getInvokeID(parent.getFullname(), name, vmSig), count);
+                CollectDetect.setInvokeCountFor(DataAbstract.getInvokeID(parent.getFullname(), name, vmSig), count);
             }
 
             @Override


### PR DESCRIPTION
CODETOOLS-7903320: Move InvokeMethodAdapter.getInvokeID(String, String, String) up

Next change to isolate ASM usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903320](https://bugs.openjdk.org/browse/CODETOOLS-7903320): Move InvokeMethodAdapter.getInvokeID(String, String, String) up


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jcov pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/26.diff">https://git.openjdk.org/jcov/pull/26.diff</a>

</details>
