### PR TITLE
CODETOOLS-7903326: Refactor CharacterRangeTableAttribute

### DIFF
--- a/src/classes/com/sun/tdk/jcov/instrument/CharacterRangeTable.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/CharacterRangeTable.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.instrument;
+
+import com.sun.tdk.jcov.data.FileFormatException;
+import com.sun.tdk.jcov.instrument.reader.Reader;
+import com.sun.tdk.jcov.instrument.reader.ReaderFactory;
+
+/**
+ * CharacterRangeTableAttribute
+ *
+ *
+ *
+ * @author Robert Field
+ */
+public class CharacterRangeTable {
+
+    public static class CRTEntry extends LocationConcrete {
+
+        public final int char_start;
+        public final int char_end;
+        public final int flags;
+        public static final int CRT_STATEMENT = 0x0001;
+        public static final int CRT_BLOCK = 0x0002;
+        public static final int CRT_ASSIGNMENT = 0x0004;
+        public static final int CRT_FLOW_CONTROLLER = 0x0008;
+        public static final int CRT_FLOW_TARGET = 0x0010;
+        public static final int CRT_INVOKE = 0x0020;
+        public static final int CRT_CREATE = 0x0040;
+        public static final int CRT_BRANCH_TRUE = 0x0080;
+        public static final int CRT_BRANCH_FALSE = 0x0100;
+
+        public CRTEntry(final int rootId,
+                final int start_pc,
+                final int end_pc,
+                final int char_start,
+                final int char_end,
+                final int flags) {
+            super(rootId, start_pc, end_pc);
+            this.char_start = char_start;
+            this.char_end = char_end;
+            this.flags = flags;
+        }
+
+        /**
+         * XML Generation
+         */
+        public String kind() {
+            return XmlNames.RANGE;
+        }
+
+        public void xmlAttrs(XmlContext ctx) {
+            super.xmlAttrs(ctx);
+            if ((flags & CRT_STATEMENT) != 0) {
+                ctx.attr(XmlNames.A_STATEMENT, true);
+            }
+            if ((flags & CRT_BLOCK) != 0) {
+                ctx.attr(XmlNames.A_BLOCK, true);
+            }
+            if ((flags & CRT_ASSIGNMENT) != 0) {
+                ctx.attr(XmlNames.A_ASSIGNMENT, true);
+            }
+            if ((flags & CRT_FLOW_CONTROLLER) != 0) {
+                ctx.attr(XmlNames.A_CONTROLLER, true);
+            }
+            if ((flags & CRT_FLOW_TARGET) != 0) {
+                ctx.attr(XmlNames.A_TARGET, true);
+            }
+            if ((flags & CRT_INVOKE) != 0) {
+                ctx.attr(XmlNames.A_INVOKE, true);
+            }
+            if ((flags & CRT_CREATE) != 0) {
+                ctx.attr(XmlNames.A_CREATE, true);
+            }
+            if ((flags & CRT_BRANCH_TRUE) != 0) {
+                ctx.attr(XmlNames.A_BRANCHTRUE, true);
+            }
+            if ((flags & CRT_BRANCH_FALSE) != 0) {
+                ctx.attr(XmlNames.A_BRANCHFALSE, true);
+            }
+        }
+
+        private void xmlPos(XmlContext ctx, int char_pos) {
+            ctx.indent();
+            ctx.format("<" + XmlNames.CRT_POS + " " + XmlNames.CRT_LINE + "='%d' "
+                    + XmlNames.CRT_COL + "='%d'/>", char_pos >> 10, char_pos & 0x3FF);
+            ctx.println();
+        }
+
+        void xmlBody(XmlContext ctx) {
+            xmlPos(ctx, char_start);
+            xmlPos(ctx, char_end);
+        }
+    }
+    public int length;
+    public CRTEntry[] entries;
+    private int rootId;
+
+    public int getRootId() {
+        return rootId;
+    }
+
+    public void setRootId(int rootId) {
+        this.rootId = rootId;
+    }
+
+    /**
+     * Creates a new instance of CharacterRangeTableAttribute
+     */
+    public CharacterRangeTable(int rootId) {
+        this(rootId, 0, new CRTEntry[0]);
+    }
+
+    public CharacterRangeTable(int rootId, int length, CRTEntry[] entries) {
+        this.length = length;
+        this.entries = entries;
+        this.rootId = rootId;
+    }
+
+    public CRTEntry[] getEntries() {
+        return entries;
+    }
+
+    public void setEntries(CRTEntry[] entries) {
+        this.entries = entries;
+    }
+
+    /*
+     * return entry with given pc and flag set,
+     * if there are more then one found , return first in source code
+     */
+    CRTEntry getEntry(int pc, int flag) {
+        CRTEntry result = null;
+        for (CRTEntry entry : getEntries()) {
+            if (entry.startBCI() == pc
+                    && (entry.flags & flag) != 0) {
+                result = (result == null) ? entry
+                        : entry.char_start < result.char_start ? entry : result;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * XML Generation
+     *
+     * Since there is no multiple inheritance, we aren't a DataAbstract, but
+     * we'll fake it
+     */
+    public void xmlGen(XmlContext ctx) {
+        ctx.indent();
+        ctx.println("<" + XmlNames.CRT + ">");
+        ctx.incIndent();
+        for (CRTEntry entry : entries) {
+            entry.xmlGen(ctx);
+        }
+        ctx.decIndent();
+        ctx.indent();
+        ctx.println("</" + XmlNames.CRT + ">");
+    }
+
+    public void readDataFrom() throws FileFormatException {
+        ReaderFactory rf = DataRoot.getInstance(rootId).getReaderFactory();
+        Reader r = rf.getReaderFor(this);
+        r.readData(this);
+    }
+
+
+    public int getPos(int line, int col) {
+        return line << 10 | col;
+    }
+}

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethodWithBlocks.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethodWithBlocks.java
@@ -25,7 +25,6 @@
 package com.sun.tdk.jcov.instrument;
 
 import com.sun.tdk.jcov.data.Scale;
-import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
 import com.sun.tdk.jcov.tools.DelegateIterator;
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -49,7 +48,7 @@ public class DataMethodWithBlocks extends DataMethod {
     /**
      *
      */
-    private CharacterRangeTableAttribute characterRangeTable = null;
+    private CharacterRangeTable characterRangeTable = null;
     /**
      * Including blocks
      */
@@ -121,7 +120,7 @@ public class DataMethodWithBlocks extends DataMethod {
      *
      * @param crt
      */
-    public void setCharacterRangeTable(CharacterRangeTableAttribute crt) {
+    public void setCharacterRangeTable(CharacterRangeTable crt) {
         this.characterRangeTable = crt;
     }
 
@@ -130,7 +129,7 @@ public class DataMethodWithBlocks extends DataMethod {
      *
      * @return
      */
-    public CharacterRangeTableAttribute getCharacterRangeTable() {
+    public CharacterRangeTable getCharacterRangeTable() {
         return characterRangeTable;
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
@@ -437,7 +437,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
     public void visitAttribute(Attribute attr) {
         super.visitAttribute(attr);
         if (attr instanceof CharacterRangeTableAttribute) {
-            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).crt);
+            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).getCrt());
         }
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/BlockCodeMethodAdapter.java
@@ -28,6 +28,7 @@ import java.util.*;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
 import com.sun.tdk.jcov.instrument.DataBlock;
 import com.sun.tdk.jcov.instrument.DataBlockFallThrough;
 import com.sun.tdk.jcov.instrument.DataBlockTargetDefault;
@@ -325,10 +326,10 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                     continue;
                 }
 
-                for (CharacterRangeTableAttribute.CRTEntry entry : method().getCharacterRangeTable().getEntries()) {
+                for (CharacterRangeTable.CRTEntry entry : method().getCharacterRangeTable().getEntries()) {
                     if (entry.startBCI() == bci) {
 
-                        if ((entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
+                        if ((entry.flags & CharacterRangeTable.CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
                             newBlock = false;
                             if (insnToBB.get(insn) == null) {
                                 //System.out.println("Should add block at: " + bci + " in " + method().name +
@@ -338,7 +339,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                             }
                         }
                     } else {
-                        if (entry.endBCI() == index && (entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_FLOW_TARGET) != 0) {
+                        if (entry.endBCI() == index && (entry.flags & CharacterRangeTable.CRTEntry.CRT_FLOW_TARGET) != 0) {
                             newBlock = true;
                         }
                     }
@@ -436,7 +437,7 @@ class BlockCodeMethodAdapter extends OffsetRecordingMethodAdapter {
     public void visitAttribute(Attribute attr) {
         super.visitAttribute(attr);
         if (attr instanceof CharacterRangeTableAttribute) {
-            method().setCharacterRangeTable((CharacterRangeTableAttribute) attr);
+            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).crt);
         }
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/BranchCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/BranchCodeMethodAdapter.java
@@ -29,6 +29,7 @@ import java.util.*;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
 import com.sun.tdk.jcov.instrument.Constants;
 import com.sun.tdk.jcov.instrument.DataBlock;
 import com.sun.tdk.jcov.instrument.DataBlockCatch;
@@ -355,10 +356,10 @@ class BranchCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                     continue;
                 }
 
-                for (CharacterRangeTableAttribute.CRTEntry entry : method().getCharacterRangeTable().getEntries()) {
+                for (CharacterRangeTable.CRTEntry entry : method().getCharacterRangeTable().getEntries()) {
                     if (entry.startBCI() == bci) {
 
-                        if ((entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
+                        if ((entry.flags & CharacterRangeTable.CRTEntry.CRT_STATEMENT) != 0 /*& newBlock*/) {
                             newBlock = false;
                             if (insnToBB.get(insn) == null) {
                                 //System.out.println("Should add block at: " + bci + " in " + method().name +
@@ -368,7 +369,7 @@ class BranchCodeMethodAdapter extends OffsetRecordingMethodAdapter {
                             }
                         }
                     } else {
-                        if (entry.endBCI() == index && (entry.flags & CharacterRangeTableAttribute.CRTEntry.CRT_FLOW_TARGET) != 0) {
+                        if (entry.endBCI() == index && (entry.flags & CharacterRangeTable.CRTEntry.CRT_FLOW_TARGET) != 0) {
                             newBlock = true;
                         }
                     }
@@ -510,7 +511,7 @@ class BranchCodeMethodAdapter extends OffsetRecordingMethodAdapter {
     public void visitAttribute(Attribute attr) {
         super.visitAttribute(attr);
         if (attr instanceof CharacterRangeTableAttribute) {
-            method().setCharacterRangeTable((CharacterRangeTableAttribute) attr);
+            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).crt);
         }
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/BranchCodeMethodAdapter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/BranchCodeMethodAdapter.java
@@ -511,7 +511,7 @@ class BranchCodeMethodAdapter extends OffsetRecordingMethodAdapter {
     public void visitAttribute(Attribute attr) {
         super.visitAttribute(attr);
         if (attr instanceof CharacterRangeTableAttribute) {
-            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).crt);
+            method().setCharacterRangeTable(((CharacterRangeTableAttribute) attr).getCrt());
         }
     }
 

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
@@ -24,17 +24,12 @@
  */
 package com.sun.tdk.jcov.instrument.asm;
 
-import com.sun.tdk.jcov.data.FileFormatException;
-import com.sun.tdk.jcov.instrument.DataRoot;
-import com.sun.tdk.jcov.instrument.LocationConcrete;
-import com.sun.tdk.jcov.instrument.XmlContext;
-import com.sun.tdk.jcov.instrument.XmlNames;
-import com.sun.tdk.jcov.instrument.reader.Reader;
-import com.sun.tdk.jcov.instrument.reader.ReaderFactory;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable.CRTEntry;
 import org.objectweb.asm.Attribute;
+import org.objectweb.asm.ByteVector;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.ByteVector;
 import org.objectweb.asm.Label;
 
 /**
@@ -46,123 +41,11 @@ import org.objectweb.asm.Label;
  */
 public class CharacterRangeTableAttribute extends Attribute {
 
-    public static class CRTEntry extends LocationConcrete {
+    CharacterRangeTable crt;
 
-        public final int char_start;
-        public final int char_end;
-        public final int flags;
-        public static final int CRT_STATEMENT = 0x0001;
-        public static final int CRT_BLOCK = 0x0002;
-        public static final int CRT_ASSIGNMENT = 0x0004;
-        public static final int CRT_FLOW_CONTROLLER = 0x0008;
-        public static final int CRT_FLOW_TARGET = 0x0010;
-        public static final int CRT_INVOKE = 0x0020;
-        public static final int CRT_CREATE = 0x0040;
-        public static final int CRT_BRANCH_TRUE = 0x0080;
-        public static final int CRT_BRANCH_FALSE = 0x0100;
-
-        public CRTEntry(final int rootId,
-                final int start_pc,
-                final int end_pc,
-                final int char_start,
-                final int char_end,
-                final int flags) {
-            super(rootId, start_pc, end_pc);
-            this.char_start = char_start;
-            this.char_end = char_end;
-            this.flags = flags;
-        }
-
-        void put(ByteVector bv) {
-            bv.putShort(startBCI());
-            bv.putShort(endBCI());
-            bv.putInt(char_start);
-            bv.putInt(char_end);
-            bv.putShort(flags);
-        }
-
-        /**
-         * XML Generation
-         */
-        public String kind() {
-            return XmlNames.RANGE;
-        }
-
-        public void xmlAttrs(XmlContext ctx) {
-            super.xmlAttrs(ctx);
-            if ((flags & CRT_STATEMENT) != 0) {
-                ctx.attr(XmlNames.A_STATEMENT, true);
-            }
-            if ((flags & CRT_BLOCK) != 0) {
-                ctx.attr(XmlNames.A_BLOCK, true);
-            }
-            if ((flags & CRT_ASSIGNMENT) != 0) {
-                ctx.attr(XmlNames.A_ASSIGNMENT, true);
-            }
-            if ((flags & CRT_FLOW_CONTROLLER) != 0) {
-                ctx.attr(XmlNames.A_CONTROLLER, true);
-            }
-            if ((flags & CRT_FLOW_TARGET) != 0) {
-                ctx.attr(XmlNames.A_TARGET, true);
-            }
-            if ((flags & CRT_INVOKE) != 0) {
-                ctx.attr(XmlNames.A_INVOKE, true);
-            }
-            if ((flags & CRT_CREATE) != 0) {
-                ctx.attr(XmlNames.A_CREATE, true);
-            }
-            if ((flags & CRT_BRANCH_TRUE) != 0) {
-                ctx.attr(XmlNames.A_BRANCHTRUE, true);
-            }
-            if ((flags & CRT_BRANCH_FALSE) != 0) {
-                ctx.attr(XmlNames.A_BRANCHFALSE, true);
-            }
-        }
-
-        private void xmlPos(XmlContext ctx, int char_pos) {
-            ctx.indent();
-            ctx.format("<" + XmlNames.CRT_POS + " " + XmlNames.CRT_LINE + "='%d' "
-                    + XmlNames.CRT_COL + "='%d'/>", char_pos >> 10, char_pos & 0x3FF);
-            ctx.println();
-        }
-
-        void xmlBody(XmlContext ctx) {
-            xmlPos(ctx, char_start);
-            xmlPos(ctx, char_end);
-        }
-    }
-    public int length;
-    public CRTEntry[] entries;
-    private int rootId;
-
-    public int getRootId() {
-        return rootId;
-    }
-
-    public void setRootId(int rootId) {
-        this.rootId = rootId;
-    }
-
-    /**
-     * Creates a new instance of CharacterRangeTableAttribute
-     */
-    public CharacterRangeTableAttribute(int rootId) {
-        this(rootId, 0, new CRTEntry[0]);
-    }
-
-    CharacterRangeTableAttribute(int rootId, int length, CRTEntry[] entries) {
+    CharacterRangeTableAttribute(CharacterRangeTable crt) {
         super("CharacterRangeTable");
-        this.length = length;
-        this.entries = entries;
-        this.rootId = rootId;
-    }
-
-    CRTEntry[] getEntries() {
-        return entries;
-    }
-
-    public void setEntries(CRTEntry[] entries) {
-        this.entries = entries;
+        this.crt = crt;
     }
 
     @Override
@@ -170,20 +53,12 @@ public class CharacterRangeTableAttribute extends Attribute {
         return false;
     }
 
-    /*
-     * return entry with given pc and flag set,
-     * if there are more then one found , return first in source code
-     */
-    CRTEntry getEntry(int pc, int flag) {
-        CRTEntry result = null;
-        for (CRTEntry entry : getEntries()) {
-            if (entry.startBCI() == pc
-                    && (entry.flags & flag) != 0) {
-                result = (result == null) ? entry
-                        : entry.char_start < result.char_start ? entry : result;
-            }
-        }
-        return result;
+    void put(CRTEntry entry, ByteVector bv) {
+        bv.putShort(entry.startBCI());
+        bv.putShort(entry.endBCI());
+        bv.putInt(entry.char_start);
+        bv.putInt(entry.char_end);
+        bv.putShort(entry.flags);
     }
 
     @Override
@@ -198,48 +73,20 @@ public class CharacterRangeTableAttribute extends Attribute {
             int char_start = cr.readInt(eoff + 4);
             int char_end = cr.readInt(eoff + 8);
             int flags = cr.readShort(eoff + 12);
-            entries[i] = new CRTEntry(rootId, start_pc, end_pc, char_start, char_end, flags);
+            entries[i] = new CRTEntry(crt.getRootId(), start_pc, end_pc, char_start, char_end, flags);
         }
-        return new CharacterRangeTableAttribute(rootId, length, entries);
+        return new CharacterRangeTableAttribute(new CharacterRangeTable(crt.getRootId(), length, entries));
     }
 
     @Override
     protected ByteVector write(ClassWriter cw, byte[] code, int len,
             int maxStack, int maxLocals) {
         ByteVector bv = new ByteVector();
-        bv.putShort(length);
-        for (CRTEntry entry : entries) {
-            entry.put(bv);
+        bv.putShort(crt.length);
+        for (CRTEntry entry : crt.entries) {
+            put(entry, bv);
         }
         return bv;
     }
 
-    /**
-     * XML Generation
-     *
-     * Since there is no multiple inheritance, we aren't a DataAbstract, but
-     * we'll fake it
-     */
-    public void xmlGen(XmlContext ctx) {
-        ctx.indent();
-        ctx.println("<" + XmlNames.CRT + ">");
-        ctx.incIndent();
-        for (CRTEntry entry : entries) {
-            entry.xmlGen(ctx);
-        }
-        ctx.decIndent();
-        ctx.indent();
-        ctx.println("</" + XmlNames.CRT + ">");
-    }
-
-    public void readDataFrom() throws FileFormatException {
-        ReaderFactory rf = DataRoot.getInstance(rootId).getReaderFactory();
-        Reader r = rf.getReaderFor(this);
-        r.readData(this);
-    }
-
-
-    public int getPos(int line, int col) {
-        return line << 10 | col;
-    }
 }

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/CharacterRangeTableAttribute.java
@@ -41,11 +41,15 @@ import org.objectweb.asm.Label;
  */
 public class CharacterRangeTableAttribute extends Attribute {
 
-    CharacterRangeTable crt;
+    private CharacterRangeTable crt;
 
     CharacterRangeTableAttribute(CharacterRangeTable crt) {
         super("CharacterRangeTable");
         this.crt = crt;
+    }
+
+    public CharacterRangeTable getCrt() {
+        return crt;
     }
 
     @Override

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
@@ -26,6 +26,7 @@ package com.sun.tdk.jcov.instrument.asm;
 
 import com.sun.tdk.jcov.data.FileFormatException;
 import com.sun.tdk.jcov.instrument.BasicBlock;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
 import com.sun.tdk.jcov.instrument.DataBlock;
 import com.sun.tdk.jcov.instrument.DataClass;
 import com.sun.tdk.jcov.instrument.DataField;
@@ -271,7 +272,8 @@ public class ClassMorph {
         ClassVisitor cv = cw;
         cv = new DeferringMethodClassAdapter(cv, k, params);
 
-        cr.accept(cv, new Attribute[]{new CharacterRangeTableAttribute(root.rootId())}, 0);
+        cr.accept(cv,
+                new Attribute[]{new CharacterRangeTableAttribute(new CharacterRangeTable(root.rootId()))}, 0);
 
         if (k.hasModifier(Opcodes.ACC_SYNTHETIC) && !params.isInstrumentSynthetic()) {
             return null;

--- a/src/classes/com/sun/tdk/jcov/instrument/reader/CharacterRangeTableAttributeStAX.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/reader/CharacterRangeTableAttributeStAX.java
@@ -25,8 +25,8 @@
 package com.sun.tdk.jcov.instrument.reader;
 
 import com.sun.tdk.jcov.data.FileFormatException;
-import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
-import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute.CRTEntry;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable.CRTEntry;
 import com.sun.tdk.jcov.instrument.XmlNames;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,11 +40,11 @@ import javax.xml.stream.XMLStreamReader;
  */
 public class CharacterRangeTableAttributeStAX implements Reader {
 
-    CharacterRangeTableAttribute crt;
+    CharacterRangeTable crt;
     private XMLStreamReader parser;
 
     public void readData(Object dest) throws FileFormatException {
-        crt = (CharacterRangeTableAttribute) dest;
+        crt = (CharacterRangeTable) dest;
         try {
             readData();
         } catch (XMLStreamException ex) {

--- a/src/classes/com/sun/tdk/jcov/instrument/reader/DataMethodWithBlocksStAX.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/reader/DataMethodWithBlocksStAX.java
@@ -26,7 +26,7 @@ package com.sun.tdk.jcov.instrument.reader;
 
 import com.sun.tdk.jcov.data.FileFormatException;
 import com.sun.tdk.jcov.instrument.BasicBlock;
-import com.sun.tdk.jcov.instrument.asm.CharacterRangeTableAttribute;
+import com.sun.tdk.jcov.instrument.CharacterRangeTable;
 import com.sun.tdk.jcov.instrument.DataAbstract.LocationCoords;
 import com.sun.tdk.jcov.instrument.DataMethodWithBlocks;
 import com.sun.tdk.jcov.instrument.DataRoot;
@@ -95,7 +95,7 @@ public class DataMethodWithBlocksStAX implements Reader {
                 bb.readDataFrom();
                 blocks.add(bb);
             } else if (XmlNames.CRT.equals(elem)) {
-                meth.setCharacterRangeTable(new CharacterRangeTableAttribute(meth.rootId()));
+                meth.setCharacterRangeTable(new CharacterRangeTable(meth.rootId()));
                 meth.getCharacterRangeTable().readDataFrom();
             } else {
                 Reader r = rf.getSuperReaderFor(DataMethodWithBlocks.class);


### PR DESCRIPTION
This extracts generic part of *.instrument.asm.CharacterRangeTableAttribute class into a new class *.instrument.CharacterRangeTable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903326](https://bugs.openjdk.org/browse/CODETOOLS-7903326): Refactor CharacterRangeTableAttribute


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/jcov pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/27.diff">https://git.openjdk.org/jcov/pull/27.diff</a>

</details>
