### PR TITLE
CODETOOLS-7903342: Wrong methods reported as synthetic

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -341,6 +341,8 @@ MILESTONE="${build.milestone}"
                classpath="${testngjar}:${build.dir}/jcov.jar"
                destdir="${result.dir}/test/classes">
         </javac>
+        <copy file="${test.src.dir}/com/sun/tdk/jcov/report/dataprocessor/syntheticity/synthetic_template.xml"
+		todir="${result.dir}/test/classes/com/sun/tdk/jcov/report/dataprocessor/syntheticity"/>
         <taskdef classname="org.testng.TestNGAntTask" classpath="${testngjar}" name="testng"/>
         <testng failureProperty="tests.failed" listeners="org.testng.reporters.VerboseReporter" outputdir="${result.dir}/test/result" suitename="jcov" testname="TestNG tests" workingDir="${result.dir}/test/work" verbose="2">
                 <classfileset dir="${result.dir}/test/classes" includes="**/*Test.class" />

--- a/src/classes/com/sun/tdk/jcov/processing/CombinerDataProcessor.java
+++ b/src/classes/com/sun/tdk/jcov/processing/CombinerDataProcessor.java
@@ -30,6 +30,7 @@ import com.sun.tdk.jcov.instrument.DataMethod;
 import com.sun.tdk.jcov.instrument.DataMethodEntryOnly;
 import com.sun.tdk.jcov.instrument.DataPackage;
 import com.sun.tdk.jcov.instrument.DataRoot;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -104,9 +105,6 @@ public class CombinerDataProcessor implements DataProcessor {
                     String prefix = createPrefix(clzName, mainClassName);
                     for (DataMethod m : c.getMethods()) {
                         int newAccess = isPublic ? m.getAccess() : makePrivate(m.getAccess());
-                        if ((c.getAccess() & Opcodes.ACC_SYNTHETIC) != 0 && (m.getAccess() & Opcodes.ACC_SYNTHETIC) == 0){
-                            newAccess = m.getAccess() | Opcodes.ACC_SYNTHETIC;
-                        }
 
                         DataMethod nm = m.clone(newClass, newAccess, prefix + m.getName());
                         // for -type=method methods exist witout blocks and branches
@@ -189,7 +187,6 @@ public class CombinerDataProcessor implements DataProcessor {
     /**
      * Scans given modifiers in attempt to find "public".
      *
-     * @param modifiers - array to scan
      * @return true if given array is not null and contains "public"
      */
     private boolean isPublic(DataClass c, DataClass outClass) {
@@ -197,7 +194,7 @@ public class CombinerDataProcessor implements DataProcessor {
             return isPublicAnonymous(c, outClass);
         }
 
-        return (c.getAccess() & Opcodes.ACC_PUBLIC) != 0;
+        return c.getModifiers().isPublic();
     }
 
     private boolean isPublicAnonymous(DataClass c, DataClass outClass) {

--- a/test/unit/com/sun/tdk/jcov/report/dataprocessor/syntheticity/SyntheticityTest.java
+++ b/test/unit/com/sun/tdk/jcov/report/dataprocessor/syntheticity/SyntheticityTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.report.dataprocessor.syntheticity;
+
+import com.sun.tdk.jcov.data.FileFormatException;
+import com.sun.tdk.jcov.instrument.DataClass;
+import com.sun.tdk.jcov.instrument.DataPackage;
+import com.sun.tdk.jcov.instrument.DataRoot;
+import com.sun.tdk.jcov.io.Reader;
+import com.sun.tdk.jcov.processing.DefaultDataProcessorSPI;
+import com.sun.tdk.jcov.processing.ProcessingException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class SyntheticityTest {
+
+    static DataRoot data;
+    static String template;
+
+    @BeforeClass
+    public static void setup() {
+        template = SyntheticityTest.class.getPackageName()
+                .replace(".", "/") + "/synthetic_template.xml";
+    }
+    @Test
+    public void load() throws FileFormatException {
+        data = Reader.readXML(ClassLoader.getSystemResourceAsStream(template));
+        DataPackage p = data.findPackage("package");
+        DataClass sc1 = p.findClass("SyntheticityClass$SyntheticClass");
+        assertTrue(sc1.findMethod("syntheticMethod").getModifiers().isSynthetic());
+        assertFalse(sc1.findMethod("nonSyntheticMethod").getModifiers().isSynthetic());
+        DataClass sc2 = p.findClass("SyntheticityClass$NonSyntheticClass");
+        assertTrue(sc2.findMethod("syntheticMethod").getModifiers().isSynthetic());
+        assertFalse(sc2.findMethod("nonSyntheticMethod").getModifiers().isSynthetic());
+    }
+    @Test(dependsOnMethods = "load")
+   public void transform() throws ProcessingException {
+        data = new DefaultDataProcessorSPI().getDataProcessor().process(data);
+        DataPackage p = data.findPackage("package");
+        DataClass sc = p.findClass("SyntheticityClass");
+        assertTrue(sc.findMethod("$SyntheticClass.syntheticMethod").getModifiers().isSynthetic());
+        assertFalse(sc.findMethod("$SyntheticClass.nonSyntheticMethod").getModifiers().isSynthetic());
+        assertTrue(sc.findMethod("$NonSyntheticClass.syntheticMethod").getModifiers().isSynthetic());
+        assertFalse(sc.findMethod("$NonSyntheticClass.nonSyntheticMethod").getModifiers().isSynthetic());
+    }
+}

--- a/test/unit/com/sun/tdk/jcov/report/dataprocessor/syntheticity/synthetic_template.xml
+++ b/test/unit/com/sun/tdk/jcov/report/dataprocessor/syntheticity/synthetic_template.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+<coverage
+        xmlns='http://java.sun.com/jcov/namespace'
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xsi:schemaLocation='http://java.sun.com/jcov/namespace coverage.xsd'>
+
+	<head>
+		<property name='coverage.generator.args' val=''/>
+		<property name='coverage.generator.mode' val='BRANCH'/>
+		<property name='coverage.generator.internal' val='include'/>
+		<property name='coverage.generator.include' val=''/>
+		<property name='coverage.generator.exclude' val=''/>
+		<property name='coverage.generator.caller_include' val='.*'/>
+		<property name='coverage.generator.caller_exclude' val=''/>
+		<property name='coverage.created.date' val='2022-09-27'/>
+		<property name='coverage.created.time' val='03:25:24'/>
+		<property name='coverage.generator.fullversion' val=' 3.0_13 (os.ea) September 26, 2022'/>
+		<property name='coverage.generator.name' val='jcov'/>
+		<property name='coverage.generator.version' val='3.0'/>
+		<property name='coverage.spec.version' val='1.3'/>
+		<property name='java.runtime.version' val='11.0.12+8-LTS-237'/>
+		<property name='java.version' val='11.0.12'/>
+		<property name='os.arch' val='x86_64'/>
+		<property name='os.name' val='Mac OS X'/>
+		<property name='os.version' val='11.5'/>
+		<property name='user.name' val='shura'/>
+		<property name='dynamic.collected' val='false'/>
+		<property name='id.count' val='4'/>
+	</head>
+	<package name="package" moduleName="no_module">
+		<class name="SyntheticityClass" supername="java/lang/Object" flags=' synthetic' source="SyntheticityClass.java">
+
+		</class>
+		<class name="SyntheticityClass$SyntheticClass" supername="java/lang/Object" flags=' synthetic' source="SyntheticityClass.java">
+			<meth name="syntheticMethod" vmsig="()V" flags=' ' access="4097" length="0">
+				<bl s="0" e="-1">
+					<methenter s="0" e="-1" id="1" count="0"/>
+				</bl>
+			</meth>
+			<meth name="nonSyntheticMethod" vmsig="()V" flags=' ' access="1" length="0">
+				<bl s="0" e="-1">
+					<methenter s="0" e="-1" id="1" count="0"/>
+				</bl>
+			</meth>
+		</class>
+		<class name="SyntheticityClass$NonSyntheticClass" supername="java/lang/Object" flags=' ' source="SyntheticityClass.java">
+			<meth name="syntheticMethod" vmsig="()V" flags=' ' access="4097" length="0">
+				<bl s="0" e="-1">
+					<methenter s="0" e="-1" id="1" count="0"/>
+				</bl>
+			</meth>
+			<meth name="nonSyntheticMethod" vmsig="()V" flags=' ' access="1" length="0">
+				<bl s="0" e="-1">
+					<methenter s="0" e="-1" id="1" count="0"/>
+				</bl>
+			</meth>
+		</class>
+	</package>
+</coverage>


### PR DESCRIPTION
The fix is removing the incorrect lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903342](https://bugs.openjdk.org/browse/CODETOOLS-7903342): Wrong methods reported as synthetic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jcov pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/29.diff">https://git.openjdk.org/jcov/pull/29.diff</a>

</details>
