### PR TITLE
Now using JTReg to run tests.

### DIFF
--- a/asm/classes/com/sun/tdk/jcov/instrument/asm/ASMInstrumentationPlugin.java
+++ b/asm/classes/com/sun/tdk/jcov/instrument/asm/ASMInstrumentationPlugin.java
@@ -35,6 +35,7 @@ import org.objectweb.asm.ModuleVisitor;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
@@ -65,13 +66,15 @@ public class ASMInstrumentationPlugin implements InstrumentationPlugin,
         String moduleName = (miURL == null) ? null : getModuleName(miURL.openStream().readAllBytes());
         ClassMorph morph = new ClassMorph(null, data, parameters);
         morph.setCurrentModuleName(moduleName);
-        for(String r : resources) {
-            byte[] content = loader.getResourceAsStream(r).readAllBytes();
-            if(isClass(r)) {
-                byte[] instrumented = morph.morph(content, loader, null);
-                //TODO should never be null
-                if(instrumented != null) saver.accept(r, instrumented);
-            } else saver.accept(r, content);
+        for (String r : resources) {
+            try (InputStream in = loader.getResourceAsStream(r)) {
+                byte[] content = in.readAllBytes();
+                if (isClass(r)) {
+                    byte[] instrumented = morph.morph(content, loader, null);
+                    //TODO should never be null
+                    if (instrumented != null) saver.accept(r, instrumented);
+                } else saver.accept(r, content);
+            }
         }
 //        moduleName = null;
     }

--- a/build/build.xml
+++ b/build/build.xml
@@ -372,24 +372,15 @@ MILESTONE="${build.milestone}"
         </echo>
     </target>
 
-    <target name="test" depends="build-jcov,build-network.saver">
-        <mkdir dir="${result.dir}/test/classes" />
-        <javac includeantruntime="false" encoding="iso-8859-1"
-               debug="no"
-               srcdir="${test.src.dir}"
-               sourcepath="${test.src.dir}"
-               classpath="${testngjar}:${build.dir}/jcov.jar"
-               destdir="${result.dir}/test/classes">
-        </javac>
-        <copy todir="${result.dir}/test/classes">
-            <fileset dir="${test.src.dir}" includes="**/*.xml"/>
-        </copy>
-        <taskdef classname="org.testng.TestNGAntTask" classpath="${testngjar}" name="testng"/>
-        <testng failureProperty="tests.failed" listeners="org.testng.reporters.VerboseReporter" outputdir="${result.dir}/test/result" suitename="jcov" testname="TestNG tests" workingDir="${result.dir}/test/work" verbose="2">
-                <classfileset dir="${result.dir}/test/classes" includes="**/*Test.class" />
-            <classpath>
-                <path path="${testngjar}:${build.dir}/jcov.jar:${build.dir}/jcov_network_saver.jar:${result.dir}/test/classes:${jcommanderjar}"/>
-            </classpath>
-        </testng>
+    <target name="test" depends="build-jcov,build-network.saver,build-file.saver">
+        <mkdir dir="${result.dir}/test" />
+        <java jar="${jtreg.home}/lib/jtreg.jar" fork="true">
+            <arg value="-cpa:${build.dir}/jcov.jar:${build.dir}/jcov_file_saver.jar"/>
+            <arg value="-workDir:${result.dir}/test/workdir"/>
+            <arg value="-reportDir:${result.dir}/test/report"/>
+            <arg value="-timeoutFactor:10"/>
+            <arg value="-v1"/>
+            <arg value="../test/unit"/>
+        </java>
     </target>
 </project>

--- a/src/classes/com/sun/tdk/jcov/JREInstr.java
+++ b/src/classes/com/sun/tdk/jcov/JREInstr.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -135,7 +136,9 @@ public class JREInstr extends JCovCMDTool {
                         InstrumentationPlugin.PathSource implantSource =
                                 new InstrumentationPlugin.PathSource(cl, implant.toPath());
                         for (String resource : implantSource.resources()) {
-                            destination.accept(resource, implantSource.loader().getResourceAsStream(resource).readAllBytes());
+                            try(InputStream in = implantSource.loader().getResourceAsStream(resource)) {
+                                destination.accept(resource, in.readAllBytes());
+                            }
                         }
                     }
                     destination.accept(MODULE_INFO_CLASS, moduleInfo);

--- a/src/classes/com/sun/tdk/jcov/ProductInstr.java
+++ b/src/classes/com/sun/tdk/jcov/ProductInstr.java
@@ -62,12 +62,6 @@ public class ProductInstr extends Instr {
             DSC_INSTRUMENT, DSC_INSTRUMENT_TO, Instr.DSC_INCLUDE_RT);
 
     @Override
-    protected InstrumentationPlugin.Destination getDestination(File outDir, Path inPath) throws IOException {
-        if (getOutDir() == null) return new InstrumentationPlugin.PathDestination(inPath);
-        else return new InstrumentationPlugin.PathDestination(Path.of(outDir.getAbsolutePath()));
-    }
-
-    @Override
     protected EnvHandler defineHandler() {
         EnvHandler superHandler = super.defineHandler();
         List<OptionDescr> opts = superHandler.getValidOptions().stream()

--- a/src/classes/com/sun/tdk/jcov/TmplGen.java
+++ b/src/classes/com/sun/tdk/jcov/TmplGen.java
@@ -62,7 +62,7 @@ public class TmplGen extends Instr {
     }
 
     @Override
-    protected InstrumentationPlugin.Destination getDestination(File outDir, Path inPath) {
+    protected InstrumentationPlugin.Destination getDestination(Path path) {
         return new InstrumentationPlugin.Destination() {
             @Override public BiConsumer<String, byte[]> saver() {return (n, c) -> {};}
             @Override public void close() {}

--- a/test/unit/TEST.properties
+++ b/test/unit/TEST.properties
@@ -1,0 +1,2 @@
+TestNG.dirs = .
+lib.dirs = /unit/com/sun/tdk/jcov/instrument/util

--- a/test/unit/com/sun/tdk/jcov/instrument/instr/InstrTest.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/instr/InstrTest.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/test/unit/com/sun/tdk/jcov/instrument/plugin/TestPlugin.java
+++ b/test/unit/com/sun/tdk/jcov/instrument/plugin/TestPlugin.java
@@ -28,6 +28,7 @@ import com.sun.tdk.jcov.instrument.InstrumentationParams;
 import com.sun.tdk.jcov.instrument.InstrumentationPlugin;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,7 +47,9 @@ public class TestPlugin implements InstrumentationPlugin {
                            InstrumentationParams parameters) throws IOException {
         for(String r : resources) {
             processed.add(r);
-            saver.accept(r, loader.getResourceAsStream(r).readAllBytes());
+            try (InputStream in = loader.getResourceAsStream(r)) {
+                saver.accept(r, in.readAllBytes());
+            }
         };
     }
 


### PR DESCRIPTION
Closing InputStream in multiple places.
Brought back some of the logic with input/output locations in Instr.

With this change all tests passed been executed through ant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jcov pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/36.diff">https://git.openjdk.org/jcov/pull/36.diff</a>

</details>
