### PR TITLE
7903520 - jcov is missing versions of testing dependencies and javatest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ hs_err_pid*
 
 # build
 JCOV_BUILD/
-
+build/template.xml

--- a/build/build.properties
+++ b/build/build.properties
@@ -27,18 +27,21 @@ asm.tree.checksum = b7eceb80554b955d73cea443f143d945f87755a5
 asm.util.checksum = 9a3fb3a5cd6364dc5ca86d832093d7bcaa4ac927
 
 # path to asm libraries
-asm.jar = asm-9.1.jar
-asm.tree.jar = asm-tree-9.1.jar
-asm.util.jar = asm-util-9.1.jar
+asm.version=9.1
+asm.jar = asm-${asm.version}.jar
+asm.tree.jar = asm-tree-${asm.version}.jar
+asm.util.jar = asm-util-${asm.version}.jar
 
 # path to javatest library (empty value allowed if you do not need jtobserver.jar)
 javatestjar = javatest.jar
 
 # path to TestNG library
-testngjar = testng.jar
+testngver = 6.9.10
+testngjar = testng-${testngver}.jar
 
 # path to JCommander library
-jcommanderjar = jcommander.jar
+jcommanderver = 1.82
+jcommanderjar = jcommander-${jcommanderver}.jar
 
 # path to output directory
 result.dir =../JCOV_BUILD

--- a/build/build.xml
+++ b/build/build.xml
@@ -97,8 +97,7 @@
 
     </target>
 
-    <target name="prepare" depends="clean, verify-dependencies" description="checks dependencies">
-
+    <target name="check-javatestjar">
         <condition property="javatest.present">
             <and>
                 <isset property="javatestjar"/>
@@ -107,12 +106,13 @@
                 </not>
             </and>
         </condition>
+    </target>
 
+    <target name="prepare" depends="clean, check-javatestjar, verify-dependencies" description="checks dependencies">
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${tmp.dir}"/>
         <mkdir dir="${jcov.src.update}"/>
         <mkdir dir="${jcov.classes}"/>
-
     </target>
 
     <target name="build-date" description="adds build and date information">
@@ -330,7 +330,7 @@ MILESTONE="${build.milestone}"
         </echo>
     </target>
 
-    <target name="test" depends="build-jcov,build-network.saver">
+    <target name="test" depends="build-jcov,build-network.saver,download-test-dependencies">
         <mkdir dir="${result.dir}/test/classes" />
         <javac includeantruntime="false" encoding="iso-8859-1"
                debug="no"

--- a/build/check-dependecies.xml
+++ b/build/check-dependecies.xml
@@ -31,8 +31,6 @@
 
     <target name="compare-asm-checksum">
         <available file="${asm.jar}" property="asm.present"/>
-        <fail unless="asm.present" message="Please, specify asm library"/>
-
         <checksum file="${asm.jar}" algorithm="sha1" property="${asm.checksum}" verifyproperty="asm.checksum.matches"/>
         <condition property="asm.checksum.differs">
             <equals arg1="${asm.checksum.matches}" arg2="false" />
@@ -74,6 +72,21 @@
         <echo message="warning: wrong checksum for ASM-util dependency" level="warning" />
     </target>
 
-    <target name="verify-dependencies" depends="verify-asm, verify-asm-tree, verify-asm-util"/>
+    <target name="verify-dependencies" depends="download-dependencies, download-javatest, verify-asm, verify-asm-tree, verify-asm-util"/>
+
+    <target name="download-dependencies">
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/${asm.version}/${asm.jar}" dest="." skipexisting="true"/>
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-tree/${asm.version}/${asm.tree.jar}" dest="." skipexisting="true"/>
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-util/${asm.version}/${asm.util.jar}" dest="." skipexisting="true"/>
+    </target>
+
+   <target name="download-javatest" if="javatest.present" description="build jtobserver jar">
+       <get src="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtharness/javatest.jar" dest="." skipexisting="true"/>
+   </target>
+
+    <target name="download-test-dependencies">
+       <get src="https://repo1.maven.org/maven2/org/testng/testng/${testngver}/${testngjar}" dest="." skipexisting="true"/>
+       <get src="https://repo1.maven.org/maven2/com/beust/jcommander/${jcommanderver}/${jcommanderjar}" dest="." skipexisting="true"/>
+   </target>
 
 </project>


### PR DESCRIPTION
jcov now:
 - downloads all necessary dependences, unless present
 - is setting up versions of testng and jcommander
 - is not setting version of javatest, simply gets latest tagged binary
 - gitignores build/template.xml

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903520](https://bugs.openjdk.org/browse/CODETOOLS-7903520): jcov is missing versions of testing dependencies and javatest (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jcov.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/40.diff">https://git.openjdk.org/jcov/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/40#issuecomment-1688677616)