### PR TITLE
7903550 - Broken backward compatibility in JCov build scripts

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -26,22 +26,25 @@ asm.checksum = 11ae50d25b0fec4cff74a2c6b217280d9c727b52
 asm.tree.checksum = b7eceb80554b955d73cea443f143d945f87755a5
 asm.util.checksum = 9a3fb3a5cd6364dc5ca86d832093d7bcaa4ac927
 
+# default dir to cumualte deps
+deps.dir=./lib
+
 # path to asm libraries
 asm.version=9.1
-asm.jar = asm-${asm.version}.jar
-asm.tree.jar = asm-tree-${asm.version}.jar
-asm.util.jar = asm-util-${asm.version}.jar
+asm.jar = ${deps.dir}/asm-${asm.version}.jar
+asm.tree.jar = ${deps.dir}/asm-tree-${asm.version}.jar
+asm.util.jar = ${deps.dir}/asm-util-${asm.version}.jar
 
 # path to javatest library (empty value allowed if you do not need jtobserver.jar)
-javatestjar = javatest.jar
+javatestjar = ${deps.dir}/javatest.jar
 
 # path to TestNG library
 testngver = 6.9.10
-testngjar = testng-${testngver}.jar
+testngjar = ${deps.dir}/testng-${testngver}.jar
 
 # path to JCommander library
 jcommanderver = 1.82
-jcommanderjar = jcommander-${jcommanderver}.jar
+jcommanderjar = ${deps.dir}/jcommander-${jcommanderver}.jar
 
 # path to output directory
 result.dir =../JCOV_BUILD

--- a/build/check-dependecies.xml
+++ b/build/check-dependecies.xml
@@ -75,18 +75,27 @@
     <target name="verify-dependencies" depends="download-dependencies, download-javatest, verify-asm, verify-asm-tree, verify-asm-util"/>
 
     <target name="download-dependencies">
-        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/${asm.version}/${asm.jar}" dest="." skipexisting="true"/>
-        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-tree/${asm.version}/${asm.tree.jar}" dest="." skipexisting="true"/>
-        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-util/${asm.version}/${asm.util.jar}" dest="." skipexisting="true"/>
+        <mkdir dir="${deps.dir}"/>
+        <basename property="asm.jar.filename" file="${asm.jar}"/>
+        <basename property="asm.tree.jar.filename" file="${asm.tree.jar}"/>
+        <basename property="asm.util.jar.filename" file="${asm.util.jar}"/>
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/${asm.version}/${asm.jar.filename}" dest="${asm.jar}" skipexisting="true"/>
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-tree/${asm.version}/${asm.tree.jar.filename}" dest="${asm.tree.jar}" skipexisting="true"/>
+        <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-util/${asm.version}/${asm.util.jar.filename}" dest="${asm.util.jar}" skipexisting="true"/>
     </target>
 
    <target name="download-javatest" if="javatest.present" description="build jtobserver jar">
-       <get src="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtharness/javatest.jar" dest="." skipexisting="true"/>
+        <mkdir dir="${deps.dir}"/>
+        <basename property="javatestjar.filename" file="${javatestjar}"/>
+       <get src="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtharness/${javatestjar.filename}" dest="${javatestjar}" skipexisting="true"/>
    </target>
 
     <target name="download-test-dependencies">
-       <get src="https://repo1.maven.org/maven2/org/testng/testng/${testngver}/${testngjar}" dest="." skipexisting="true"/>
-       <get src="https://repo1.maven.org/maven2/com/beust/jcommander/${jcommanderver}/${jcommanderjar}" dest="." skipexisting="true"/>
+        <mkdir dir="${deps.dir}"/>
+        <basename property="testngjar.filename" file="${testngjar}"/>
+        <basename property="jcommanderjar.filename" file="${jcommanderjar}"/>
+       <get src="https://repo1.maven.org/maven2/org/testng/testng/${testngver}/${testngjar.filename}" dest="${testngjar}" skipexisting="true"/>
+       <get src="https://repo1.maven.org/maven2/com/beust/jcommander/${jcommanderver}/${jcommanderjar.filename}" dest="${jcommanderjar}" skipexisting="true"/>
    </target>
 
 </project>


### PR DESCRIPTION
By using proper target name, 7903550is now fixed.
Custom path, or even custom name can be (again) provided via both -D runtime property or via build.proeprties.

Accidenatly, also CODETOOLS-7903551 was fixed.
7903551 - Move JCov dependencies into a sub-dir.
Now the libs are by default downloaded to the build/./lib This directoy canbe changed via deps.dir property, so now you can manage the whole folder with deps by one property if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903550](https://bugs.openjdk.org/browse/CODETOOLS-7903550): Broken backward compatibility in JCov build scripts (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jcov.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/43.diff">https://git.openjdk.org/jcov/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/43#issuecomment-1721372346)