### PR TITLE
7903711: Rewrite simple methods ANC plugin to classfile API

### DIFF
--- a/plugins/simple_methods_anc/build.xml
+++ b/plugins/simple_methods_anc/build.xml
@@ -34,17 +34,26 @@
   <property name="test.jar" location="${build}/tests.jar"/>
   <property name="jar" location="${build}/SimpleMethods.jar"/>
   <property name="test.results" location="${build}/test_results"/>
-  <property name="jcov.jar" location="../../JCOV_BUILD/jcov_3.0/jcov.jar"/>
+  <property name="jcov.jar.dir" location="../../JCOV_BUILD/jcov_3.0"/>
+  <property name="jcov.classpath" location="${jcov.jar.dir}/jcov.jar"/>
 
   <target name="compile">
-    <available file="${jcov.jar}" property="jcov-jar-exists"/>
+    <available file="${jcov.classpath}" property="jcov-jar-exists"/>
     <fail unless="jcov-jar-exists" message="There is no ${jcov.jar}"/>
     <mkdir dir="${classes}"/>
-    <javac srcdir="${src}" classpath="${jcov.jar}" destdir="${classes}"/>
+    <javac srcdir="${src}" classpath="${jcov.classpath}" destdir="${classes}">
+      <compilerarg value='--enable-preview'/>
+      <compilerarg value='--source'/>
+      <compilerarg value='22'/>
+    </javac>
   </target>
 
   <target name="jar" depends="compile">
-    <jar jarfile="${jar}" basedir="${classes}"/>
+     <jar jarfile="${jar}" basedir="${classes}"/>
+  </target>
+
+  <target name="dist" depends="jar">
+    <copy file="${jar}" todir="${jcov.jar.dir}"/>
   </target>
 
   <target name="clean">
@@ -54,7 +63,11 @@
   <target name="compile-test">
     <fail unless="testng.classpath" message="Please specify testng.classpath"/>
     <mkdir dir="${test.classes}"/>
-    <javac srcdir="${test}" classpath="${classes}:${jcov.jar}:${testng.classpath}" destdir="${test.classes}"/>
+    <javac srcdir="${test}" classpath="${classes}:${jcov.classpath}:${testng.classpath}" destdir="${test.classes}">
+      <compilerarg value='--enable-preview'/>
+      <compilerarg value='--source'/>
+      <compilerarg value='22'/>
+    </javac>
   </target>
 
   <target name="test" depends="compile,compile-test">
@@ -65,7 +78,8 @@
       <propertyref name="test.classes"/>
       <propertyref name="test.jar"/>
     </propertyset>
-    <testng classpath="${classes}:${jcov.jar}:${test.classes}:${testng.classpath}" outputDir="${test.results}">
+    <testng classpath="${classes}:${jcov.classpath}:${test.classes}:${testng.classpath}" outputDir="${test.results}">
+      <jvmarg value='--enable-preview'/>
       <classfileset dir="${test.classes}" includes="**/*.class"/>
       <propertyset refid="test.bytecode"/>
     </testng>

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Delegators.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Delegators.java
@@ -57,16 +57,20 @@ public class Delegators implements BiPredicate<ClassModel, MethodModel> {
         if (m.code().isPresent()) {
             var iter = new InstructionIterator(m.code().get());
             Instruction next = iter.next(i -> !isSimpleInstruction(i.opcode()));
-            if (next == null || !isInvokeInstruction(next.opcode())) return false;
+            if (next == null || !isInvokeInstruction(next.opcode()))
+                return false;
             if(sameNameDelegationOnly) {
                 String name = switch (next) {
                     case InvokeInstruction ii -> ii.name().toString();
                     case InvokeDynamicInstruction idi -> idi.name().toString();
                     default -> throw new IllegalStateException(STR."Unknown node type: \{next.getClass().getName()}");
                 };
-                if (!m.methodName().toString().equals(name)) return false;
+                if (!m.methodName().toString().equals(name))
+                    return false;
             }
             return isReturnInstruction(iter.next(i -> true).opcode());
-        } else return false;
+        } else {
+            return false;
+        }
     }
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/EmptyMethods.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/EmptyMethods.java
@@ -25,6 +25,7 @@
 package openjdk.jcov.filter.simplemethods;
 
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.util.function.BiPredicate;
@@ -35,7 +36,7 @@ public class EmptyMethods implements BiPredicate<ClassModel, MethodModel> {
     @Override
     public boolean test(ClassModel node, MethodModel m) {
         if (m.code().isPresent()) {
-            var next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
+            Instruction next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
             return next.opcode() == Opcode.RETURN;
         } else return false;
     }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/EmptyMethods.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/EmptyMethods.java
@@ -38,6 +38,8 @@ public class EmptyMethods implements BiPredicate<ClassModel, MethodModel> {
         if (m.code().isPresent()) {
             Instruction next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
             return next.opcode() == Opcode.RETURN;
-        } else return false;
+        } else {
+            return false;
+        }
     }
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
@@ -25,6 +25,7 @@
 package openjdk.jcov.filter.simplemethods;
 
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.util.function.BiPredicate;
@@ -39,7 +40,7 @@ public class Getters implements BiPredicate<ClassModel, MethodModel> {
     @Override
     public boolean test(ClassModel clazz, MethodModel m) {
         if (m.code().isPresent()) {
-            var next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
+            Instruction next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
             return next != null && Utils.isReturnInstruction(next.opcode()) && next.opcode() != Opcode.RETURN;
         } else return false;
     }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,23 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.MethodNode;
-
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.Opcode;
 import java.util.function.BiPredicate;
 
-import static org.objectweb.asm.Opcodes.RETURN;
+import static openjdk.jcov.filter.simplemethods.Utils.isSimpleInstruction;
 
-public class Getters implements BiPredicate<ClassNode, MethodNode> {
+public class Getters implements BiPredicate<ClassModel, MethodModel> {
     /**
      * Identifies simple getters. A simple getter is a method obtaining a value with a "simple" code and returning it.
-     * @see Utils#isSimpleInstruction(int)
+     * @see Utils#isSimpleInstruction(java.lang.classfile.Opcode)
      */
     @Override
-    public boolean test(ClassNode clazz, MethodNode m) {
-        int index = 0;
-        int opCode = -1;
-        //skip all instructions allowed to get values
-        for(; index < m.instructions.size(); index++) {
-            opCode = m.instructions.get(index).getOpcode();
-            if(opCode >=0) {
-                if (!Utils.isSimpleInstruction(opCode)) {
-                    break;
-                }
-            }
-        }
-        //that should be a return instruction, but returning a value
-        return Utils.isReturnInstruction(opCode) && opCode != RETURN;
+    public boolean test(ClassModel clazz, MethodModel m) {
+        if (m.code().isPresent()) {
+            var next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
+            return next != null && Utils.isReturnInstruction(next.opcode()) && next.opcode() != Opcode.RETURN;
+        } else return false;
     }
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Getters.java
@@ -42,6 +42,8 @@ public class Getters implements BiPredicate<ClassModel, MethodModel> {
         if (m.code().isPresent()) {
             Instruction next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
             return next != null && Utils.isReturnInstruction(next.opcode()) && next.opcode() != Opcode.RETURN;
-        } else return false;
+        } else {
+            return false;
+        }
     }
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,26 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import java.lang.classfile.ClassModel;
-import java.lang.classfile.MethodModel;
-import java.lang.classfile.Opcode;
-import java.util.function.BiPredicate;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.Instruction;
+import java.util.Iterator;
+import java.util.function.Predicate;
 
-import static openjdk.jcov.filter.simplemethods.Utils.isSimpleInstruction;
+public class InstructionIterator {
+    private final Iterator<CodeElement> elements;
 
-public class EmptyMethods implements BiPredicate<ClassModel, MethodModel> {
-    @Override
-    public boolean test(ClassModel node, MethodModel m) {
-        if (m.code().isPresent()) {
-            var next = new InstructionIterator(m.code().get()).next(i -> !isSimpleInstruction(i.opcode()));
-            return next.opcode() == Opcode.RETURN;
-        } else return false;
+    public InstructionIterator(CodeModel model) {
+        elements = model.elements().iterator();
+    }
+
+    public Instruction next(Predicate<Instruction> criteria) {
+        while (elements.hasNext()) {
+            var next = elements.next();
+            if (next instanceof Instruction i) {
+                if(criteria.test(i)) return i;
+            }
+        }
+        return null;
     }
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
@@ -41,7 +41,8 @@ public class InstructionIterator {
         while (elements.hasNext()) {
             CodeElement next = elements.next();
             if (next instanceof Instruction i) {
-                if(criteria.test(i)) return i;
+                if(criteria.test(i))
+                    return i;
             }
         }
         return null;

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/InstructionIterator.java
@@ -39,7 +39,7 @@ public class InstructionIterator {
 
     public Instruction next(Predicate<Instruction> criteria) {
         while (elements.hasNext()) {
-            var next = elements.next();
+            CodeElement next = elements.next();
             if (next instanceof Instruction i) {
                 if(criteria.test(i)) return i;
             }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Setters.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Setters.java
@@ -25,6 +25,7 @@
 package openjdk.jcov.filter.simplemethods;
 
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.util.function.BiPredicate;
@@ -41,7 +42,7 @@ public class Setters implements BiPredicate<ClassModel, MethodModel> {
     public boolean test(ClassModel clazz, MethodModel m) {
         if (m.code().isPresent()) {
             var iter = new InstructionIterator(m.code().get());
-            var next = iter.next(i -> !isSimpleInstruction(i.opcode()));
+            Instruction next = iter.next(i -> !isSimpleInstruction(i.opcode()));
             if (next.opcode() != Opcode.PUTFIELD && next.opcode() != Opcode.PUTSTATIC) return false;
             next = iter.next(i -> !isSimpleInstruction(i.opcode()));
             return next.opcode() == Opcode.RETURN;

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Setters.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Setters.java
@@ -43,7 +43,8 @@ public class Setters implements BiPredicate<ClassModel, MethodModel> {
         if (m.code().isPresent()) {
             var iter = new InstructionIterator(m.code().get());
             Instruction next = iter.next(i -> !isSimpleInstruction(i.opcode()));
-            if (next.opcode() != Opcode.PUTFIELD && next.opcode() != Opcode.PUTSTATIC) return false;
+            if (next.opcode() != Opcode.PUTFIELD && next.opcode() != Opcode.PUTSTATIC)
+                return false;
             next = iter.next(i -> !isSimpleInstruction(i.opcode()));
             return next.opcode() == Opcode.RETURN;
         } else return false;

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Throwers.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Throwers.java
@@ -25,6 +25,7 @@
 package openjdk.jcov.filter.simplemethods;
 
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.Instruction;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.instruction.InvokeInstruction;
@@ -42,7 +43,7 @@ public class Throwers implements BiPredicate<ClassModel, MethodModel> {
             //next is DUP
             if(iter.next(i -> true).opcode() != Opcode.DUP) return false;
             //next is a constructor call
-            var next = iter.next(i -> !isSimpleInstruction(i.opcode()));
+            Instruction next = iter.next(i -> !isSimpleInstruction(i.opcode()));
             if (next.opcode() != Opcode.INVOKESPECIAL) return false;
             if (next instanceof InvokeInstruction call) {
                 if (!call.name().toString().equals("<init>")) return false;

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Throwers.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Throwers.java
@@ -39,15 +39,20 @@ public class Throwers implements BiPredicate<ClassModel, MethodModel> {
         if (m.code().isPresent()) {
             var iter = new InstructionIterator(m.code().get());
             //first should be NEW
-            if(iter.next(i -> true).opcode() != Opcode.NEW) return false;
+            if(iter.next(i -> true).opcode() != Opcode.NEW)
+                return false;
             //next is DUP
-            if(iter.next(i -> true).opcode() != Opcode.DUP) return false;
+            if(iter.next(i -> true).opcode() != Opcode.DUP)
+                return false;
             //next is a constructor call
             Instruction next = iter.next(i -> !isSimpleInstruction(i.opcode()));
-            if (next.opcode() != Opcode.INVOKESPECIAL) return false;
+            if (next.opcode() != Opcode.INVOKESPECIAL)
+                return false;
             if (next instanceof InvokeInstruction call) {
                 if (!call.name().toString().equals("<init>")) return false;
-            } else return false;
+            } else {
+                return false;
+            }
             //finally a throw
             return iter.next(i -> true).opcode() == Opcode.ATHROW;
         } else return false;

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Utils.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,24 +24,30 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
+import java.lang.classfile.Opcode;
 import java.util.Arrays;
 
-import static org.objectweb.asm.Opcodes.*;
+import static java.lang.classfile.Opcode.*;
 
 public class Utils {
-    private final static int[] SIMPLE_INSTRUCTIONS = new int[]{DUP, LDC,
+    private final static Opcode[] SIMPLE_INSTRUCTIONS = new Opcode[]{
+            DUP, LDC,
             BALOAD, CALOAD, AALOAD, DALOAD, FALOAD, IALOAD, SALOAD,
             ACONST_NULL,
             ICONST_0, ICONST_1, ICONST_2, ICONST_3, ICONST_4, ICONST_5, ICONST_M1,
             LCONST_0, LCONST_1,
             FCONST_0, FCONST_1, FCONST_2,
             DCONST_0, DCONST_1,
-            ALOAD, ILOAD, FLOAD, LLOAD, DLOAD,
+            ALOAD, ALOAD_0, ALOAD_1, ALOAD_2, ALOAD_3, ALOAD_W,
+            ILOAD, ILOAD_0, ILOAD_1, ILOAD_2, ILOAD_3, ILOAD_W,
+            FLOAD, FLOAD_0, FLOAD_1, FLOAD_2, FLOAD_3, FLOAD_W,
+            LLOAD, LLOAD_0, LLOAD_1, LLOAD_2, LLOAD_3, LLOAD_W,
+            DLOAD, DLOAD_0, DLOAD_1, DLOAD_2, DLOAD_3, DLOAD_W,
             GETFIELD, GETSTATIC,
             BIPUSH, SIPUSH};
-    private final static int[] INVOKE_INSTRUCTIONS = new int[]{INVOKEVIRTUAL, INVOKEINTERFACE, INVOKESTATIC,
+    private final static Opcode[] INVOKE_INSTRUCTIONS = new Opcode[]{INVOKEVIRTUAL, INVOKEINTERFACE, INVOKESTATIC,
             INVOKEDYNAMIC, INVOKESPECIAL};
-    private final static int[] RETURN_INSTRUCTIONS = new int[]{RETURN, ARETURN, IRETURN, FRETURN, LRETURN, DRETURN};
+    private final static Opcode[] RETURN_INSTRUCTIONS = new Opcode[]{RETURN, ARETURN, IRETURN, FRETURN, LRETURN, DRETURN};
 
     static {
         Arrays.sort(SIMPLE_INSTRUCTIONS);
@@ -54,13 +60,14 @@ public class Utils {
      * @param opCode
      * @return
      */
-    public static boolean isSimpleInstruction(int opCode) {
+    public static boolean isSimpleInstruction(Opcode opCode) {
         return Arrays.binarySearch(SIMPLE_INSTRUCTIONS, opCode) >= 0;
     }
-    public static boolean isReturnInstruction(int opCode) {
+    public static boolean isReturnInstruction(Opcode opCode) {
         return Arrays.binarySearch(RETURN_INSTRUCTIONS, opCode) >= 0;
     }
-    public static boolean isInvokeInstruction(int opCode) {
+    public static boolean isInvokeInstruction(Opcode opCode) {
         return Arrays.binarySearch(INVOKE_INSTRUCTIONS, opCode) >= 0;
     }
+
 }

--- a/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Utils.java
+++ b/plugins/simple_methods_anc/src/openjdk/jcov/filter/simplemethods/Utils.java
@@ -31,7 +31,8 @@ import static java.lang.classfile.Opcode.*;
 
 public class Utils {
     private final static Opcode[] SIMPLE_INSTRUCTIONS = new Opcode[]{
-            DUP, LDC,
+            DUP,
+            LDC, LDC_W, LDC2_W,
             BALOAD, CALOAD, AALOAD, DALOAD, FALOAD, IALOAD, SALOAD,
             ACONST_NULL,
             ICONST_0, ICONST_1, ICONST_2, ICONST_3, ICONST_4, ICONST_5, ICONST_M1,

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/DelegatorsTest.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/DelegatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,12 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.classfile.ClassModel;
 
 import static org.testng.Assert.assertEquals;
 
@@ -37,7 +37,7 @@ public class DelegatorsTest {
 
     Delegators any_name_delegator;
     Delegators same_name_delegator;
-    ClassNode cls;
+    ClassModel cls;
 
     @BeforeTest
     public void init() throws IOException {

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/EmptyMethodsTest.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/EmptyMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,19 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.classfile.ClassModel;
 
 import static org.testng.Assert.assertEquals;
 
 public class EmptyMethodsTest {
 
     EmptyMethods tested;
-    ClassNode cls;
+    ClassModel cls;
 
     @BeforeTest
     public void init() throws IOException {

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/GettersTest.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/GettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,12 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.classfile.ClassModel;
 
 import static openjdk.jcov.filter.simplemethods.TestUtils.findTestMethod;
 import static org.testng.Assert.assertEquals;
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertEquals;
 public class GettersTest {
 
     Getters tested;
-    ClassNode cls;
+    ClassModel cls;
 
     @BeforeTest
     public void init() throws IOException {

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/SettersTest.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/SettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,19 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.classfile.ClassModel;
 
 import static org.testng.Assert.assertEquals;
 
 public class SettersTest {
 
     Setters tested;
-    ClassNode cls;
+    ClassModel cls;
 
     @BeforeTest
     public void init() throws IOException {

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/TestUtils.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018,2024  Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,28 +24,20 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.MethodNode;
-
 import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
 
 public class TestUtils {
-    static ClassNode findTestClass(Class cls) throws IOException {
-        ClassNode result = new ClassNode();
-        ClassReader reader = new ClassReader(cls.getClassLoader().
-                getResourceAsStream(cls.getName().replace('.','/') + ".class"));
-        reader.accept(result, 0);
-        return result;
+    static ClassModel findTestClass(Class cls) throws IOException {
+        return ClassFile.of().parse(cls.getClassLoader().
+                getResourceAsStream(cls.getName().replace('.','/') + ".class").readAllBytes());
     }
 
-    static MethodNode findTestMethod(ClassNode cls, String methodSig)  {
-        for(Object mo: cls.methods) {
-            MethodNode m = (MethodNode) mo;
-            if((m.name + m.desc).equals(methodSig)) {
-                return m;
-            }
-        }
-        throw new IllegalStateException("Method does not exist: " + methodSig + " in class " + cls.name);
+    static MethodModel findTestMethod(ClassModel cls, String methodSig)  {
+        return cls.methods().stream()
+                .filter(m -> (m.methodName().toString() + m.methodType().toString()).equals(methodSig))
+                .findAny().get();
     }
 }

--- a/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/ThrowersTest.java
+++ b/plugins/simple_methods_anc/test/openjdk/jcov/filter/simplemethods/ThrowersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,12 @@
  */
 package openjdk.jcov.filter.simplemethods;
 
-import org.objectweb.asm.tree.ClassNode;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.classfile.ClassModel;
 
 import static openjdk.jcov.filter.simplemethods.TestUtils.findTestMethod;
 import static org.testng.Assert.assertEquals;
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertEquals;
 public class ThrowersTest {
 
     Throwers tested;
-    ClassNode cls;
+    ClassModel cls;
 
     @BeforeTest
     public void init() throws IOException {


### PR DESCRIPTION
Rewritten using JDK 22.

openjdk.jcov.filter.simplemethods.InstructionIterator make the code a lot simpler.

No change needed to tests, except to change from ASM ClassNode to ClassModel from the classfile API

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903711](https://bugs.openjdk.org/browse/CODETOOLS-7903711): Rewrite simple methods ANC plugin to classfile API (**Task** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/jcov.git pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/44.diff">https://git.openjdk.org/jcov/pull/44.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/44#issuecomment-2050770343)