### PR TITLE
7903811: Build fail because of newer Java syntax used

### DIFF
--- a/src/classes/com/sun/tdk/jcov/runtime/JCovXMLFileSaver.java
+++ b/src/classes/com/sun/tdk/jcov/runtime/JCovXMLFileSaver.java
@@ -85,11 +85,13 @@ public class JCovXMLFileSaver extends FileSaver {
                         os = zos;
                     } else os = baos;
 
-                    try (os) {
+                    try {
                         XmlContext ctx = new XmlContext(os, root.getParams());
                         ctx.setSkipNotCoveredClasses(agentdata);
                         root.xmlGen(ctx);
                         ctx.close();
+                    } finally {
+                        os.close();
                     }
 
                     channel.truncate(0);


### PR DESCRIPTION
Use older syntax for now.
Review the build JDK version later

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903811](https://bugs.openjdk.org/browse/CODETOOLS-7903811): Build fail because of newer Java syntax used (**Bug** - P1)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jcov.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/47.diff">https://git.openjdk.org/jcov/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/47#issuecomment-2322170348)