### PR TITLE
7903842: Negative coverage in report for records

### DIFF
--- a/build/release.properties
+++ b/build/release.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,4 +23,4 @@
 
 build.version = 3.0
 build.milestone = os.ea
-build.number = 13
+build.number = 14

--- a/src/classes/.gitignore
+++ b/src/classes/.gitignore
@@ -1,0 +1,29 @@
+### IntelliJ IDEA ###
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/src/classes/com/sun/tdk/jcov/RepGen.java
+++ b/src/classes/com/sun/tdk/jcov/RepGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,48 +24,37 @@
  */
 package com.sun.tdk.jcov;
 
-import com.sun.tdk.jcov.instrument.DataMethod;
-import com.sun.tdk.jcov.instrument.DataClass;
-import com.sun.tdk.jcov.instrument.DataField;
-import com.sun.tdk.jcov.processing.DataProcessorSPI;
-import com.sun.tdk.jcov.report.AncFilter;
-import com.sun.tdk.jcov.report.ParameterizedAncFilter;
-import com.sun.tdk.jcov.report.AncFilterFactory;
-import com.sun.tdk.jcov.util.Utils;
 import com.sun.tdk.jcov.data.FileFormatException;
 import com.sun.tdk.jcov.data.Result;
-import com.sun.tdk.jcov.instrument.DataRoot;
-import com.sun.tdk.jcov.processing.ProcessingException;
-
-import com.sun.tdk.jcov.tools.EnvHandler;
-import com.sun.tdk.jcov.tools.OptionDescr;
-import com.sun.tdk.jcov.io.Reader;
 import com.sun.tdk.jcov.filter.ConveyerFilter;
-import com.sun.tdk.jcov.filter.MemberFilter;
 import com.sun.tdk.jcov.filter.FilterFactory;
-import com.sun.tdk.jcov.instrument.InstrumentationOptions;
+import com.sun.tdk.jcov.filter.MemberFilter;
+import com.sun.tdk.jcov.instrument.*;
 import com.sun.tdk.jcov.io.ClassSignatureFilter;
+import com.sun.tdk.jcov.io.Reader;
+import com.sun.tdk.jcov.processing.DataProcessorSPI;
 import com.sun.tdk.jcov.processing.DefaultDataProcessorSPI;
+import com.sun.tdk.jcov.processing.ProcessingException;
 import com.sun.tdk.jcov.processing.StubSpi;
-import com.sun.tdk.jcov.report.DefaultReportGeneratorSPI;
-import com.sun.tdk.jcov.report.ProductCoverage;
-import com.sun.tdk.jcov.report.ReportGenerator;
-import com.sun.tdk.jcov.report.ReportGeneratorSPI;
-import com.sun.tdk.jcov.report.SmartTestService;
+import com.sun.tdk.jcov.report.*;
 import com.sun.tdk.jcov.report.javap.JavapClass;
 import com.sun.tdk.jcov.report.javap.JavapRepGen;
+import com.sun.tdk.jcov.tools.EnvHandler;
 import com.sun.tdk.jcov.tools.JCovCMDTool;
+import com.sun.tdk.jcov.tools.OptionDescr;
 import com.sun.tdk.jcov.tools.SPIDescr;
+import com.sun.tdk.jcov.util.Utils;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.sun.tdk.jcov.tools.OptionDescr.*;
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
+import static com.sun.tdk.jcov.tools.OptionDescr.VAL_SINGLE;
 
 /**
  * <p> Report generation. </p>
@@ -85,6 +74,7 @@ public class RepGen extends JCovCMDTool {
         Utils.initLogger();
         logger = Logger.getLogger(RepGen.class.getName());
     }
+
     private final static Logger logger;
     /**
      * Consider or not enums. true - means ignore enum classes.
@@ -199,7 +189,7 @@ public class RepGen extends JCovCMDTool {
      * @param output
      * @param jcovResult
      * @param srcRootPath
-     * @param classes parsed javap classes
+     * @param classes     parsed javap classes
      * @throws ProcessingException
      * @throws FileFormatException
      * @throws Exception
@@ -233,7 +223,7 @@ public class RepGen extends JCovCMDTool {
             logger.fine("OK");
         }
 
-        if (ancfilters != null){
+        if (ancfilters != null) {
             ancfiltersClasses = new AncFilter[ancfilters.length];
             for (int i = 0; i < ancfilters.length; i++) {
                 try {
@@ -312,7 +302,7 @@ public class RepGen extends JCovCMDTool {
             sts = new SmartTestService(jcovResult.getTestList());
             if (file_image.getScaleOpts().getScaleSize() != sts.getTestCount()) {
                 logger.log(Level.SEVERE, "The sizes of tests in JCov file and in test list differ.\n"
-                        + "Datafile {0} contains {1} item(s).\nThe test list contains {2} item(s).",
+                                + "Datafile {0} contains {1} item(s).\nThe test list contains {2} item(s).",
                         new Object[]{jcovResult.getResultPath(), file_image.getScaleOpts().getScaleSize(), sts.getTestCount()});
                 throw new Exception("The sizes of tests in JCov file and in test list differ");
             }
@@ -344,10 +334,9 @@ public class RepGen extends JCovCMDTool {
     }
 
     private ReportGenerator findReportGenerator(String name) {
-        ReportGenerator rg = null;
         if (reportGeneratorSPIs != null) {
             for (ReportGeneratorSPI reportGeneratorSPI : reportGeneratorSPIs) {
-                rg = reportGeneratorSPI.getReportGenerator(name);
+                ReportGenerator rg = reportGeneratorSPI.getReportGenerator(name);
                 if (rg != null) {
                     return rg;
                 }
@@ -508,7 +497,7 @@ public class RepGen extends JCovCMDTool {
         return srcRootPath;
     }
 
-    public void setDataProcessorsSPIs(DataProcessorSPI[] dataProcessorSPIs){
+    public void setDataProcessorsSPIs(DataProcessorSPI[] dataProcessorSPIs) {
         this.dataProcessorSPIs = dataProcessorSPIs;
     }
 
@@ -534,24 +523,24 @@ public class RepGen extends JCovCMDTool {
     /**
      * Set all properties (except custorm report service provider)
      *
-     * @param include patterns for including data. Set null for default value -
-     * {".*"} (include all)
-     * @param exclude patterns for excluding data. Set null for default value -
-     * {""} (exclude nothing)
-     * @param classModifiers modifiers that should have a class to be included
-     * @param filter custom filter classname
+     * @param include             patterns for including data. Set null for default value -
+     *                            {".*"} (include all)
+     * @param exclude             patterns for excluding data. Set null for default value -
+     *                            {""} (exclude nothing)
+     * @param classModifiers      modifiers that should have a class to be included
+     * @param filter              custom filter classname
      * @param generateShortFormat should generate short format
-     * @param publicAPI should generate only public API (public and protected)
-     * @param hideAbstract should hide abstract data
-     * @param hideMethods should hide methods
-     * @param hideBlocks should hide blocks
-     * @param hideBranches should hide branches
-     * @param hideLines should hide lines
+     * @param publicAPI           should generate only public API (public and protected)
+     * @param hideAbstract        should hide abstract data
+     * @param hideMethods         should hide methods
+     * @param hideBlocks          should hide blocks
+     * @param hideBranches        should hide branches
+     * @param hideLines           should hide lines
      */
     public void configure(String[] include, String[] exclude, String[] classModifiers,
-            String filter, boolean generateShortFormat, boolean publicAPI, boolean hideAbstract,
-            boolean hideMethods, boolean hideBlocks, boolean hideBranches, boolean hideLines,
-            boolean hideFields) {
+                          String filter, boolean generateShortFormat, boolean publicAPI, boolean hideAbstract,
+                          boolean hideMethods, boolean hideBlocks, boolean hideBranches, boolean hideLines,
+                          boolean hideFields) {
         setFilters(include, exclude, classModifiers);
         setFilter(filter);
         this.isPublicAPI = publicAPI;
@@ -561,10 +550,10 @@ public class RepGen extends JCovCMDTool {
     /**
      * Set filtering properties for the report
      *
-     * @param include patterns for including data. Set null for default value -
-     * {".*"} (include all)
-     * @param exclude patterns for excluding data. Set null for default value -
-     * {""} (exclude nothing)
+     * @param include        patterns for including data. Set null for default value -
+     *                       {".*"} (include all)
+     * @param exclude        patterns for excluding data. Set null for default value -
+     *                       {""} (exclude nothing)
      * @param classModifiers modifiers that should have a class to be included
      */
     public void setFilters(String[] include, String[] exclude, String[] classModifiers) {
@@ -687,34 +676,34 @@ public class RepGen extends JCovCMDTool {
     @Override
     protected EnvHandler defineHandler() {
         EnvHandler envHandler = new EnvHandler(new OptionDescr[]{
-                    DSC_FMT,
-                    DSC_OUTPUT,
-                    //            DSC_STDOUT,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_INCLUDE,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_EXCLUDE,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_INCLUDE_LIST,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_EXCLUDE_LIST,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MINCLUDE_LIST,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MEXCLUDE_LIST,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MINCLUDE,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MEXCLUDE,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_FM,
-                    com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_FM_LIST,
-                    DSC_NO_ABSTRACT,
-                    DSC_SYNTHETIC_ON,
-                    DSC_PUBLIC_API,
-                    DSC_SRC_ROOT,
-                    DSC_VERBOSE,
-                    DSC_FILTER_PLUGIN,
-                    DSC_ANC_FILTER_PLUGINS,
-                    DSC_ANC_DEFAULT_FILTERS,
-                    DSC_TEST_LIST,
-                    DSC_ANONYM,
-                    DSC_JAVAP,
-                    DSC_TESTS_INFO,
-                    DSC_REPORT_TITLE_MAIN,
-                    DSC_REPORT_TITLE_OVERVIEW,
-                    DSC_REPORT_TITLE_ENTITIES,}, this);
+                DSC_FMT,
+                DSC_OUTPUT,
+                //            DSC_STDOUT,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_INCLUDE,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_EXCLUDE,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_INCLUDE_LIST,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_EXCLUDE_LIST,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MINCLUDE_LIST,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MEXCLUDE_LIST,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MINCLUDE,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_MEXCLUDE,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_FM,
+                com.sun.tdk.jcov.instrument.InstrumentationOptions.DSC_FM_LIST,
+                DSC_NO_ABSTRACT,
+                DSC_SYNTHETIC_ON,
+                DSC_PUBLIC_API,
+                DSC_SRC_ROOT,
+                DSC_VERBOSE,
+                DSC_FILTER_PLUGIN,
+                DSC_ANC_FILTER_PLUGINS,
+                DSC_ANC_DEFAULT_FILTERS,
+                DSC_TEST_LIST,
+                DSC_ANONYM,
+                DSC_JAVAP,
+                DSC_TESTS_INFO,
+                DSC_REPORT_TITLE_MAIN,
+                DSC_REPORT_TITLE_OVERVIEW,
+                DSC_REPORT_TITLE_ENTITIES,}, this);
         SPIDescr spiDescr = new SPIDescr(CUSTOM_REPORT_GENERATOR_SPI, ReportGeneratorSPI.class);
         spiDescr.setDefaultSPI(new DefaultReportGeneratorSPI());
         envHandler.registerSPI(spiDescr);
@@ -764,13 +753,13 @@ public class RepGen extends JCovCMDTool {
             srcRootPath = opts.getValue(DSC_SRC_ROOT);
         }
 
-        if (opts.isSet(DSC_REPORT_TITLE_MAIN)){
+        if (opts.isSet(DSC_REPORT_TITLE_MAIN)) {
             mainReportTitle = opts.getValue(DSC_REPORT_TITLE_MAIN);
         }
-        if (opts.isSet(DSC_REPORT_TITLE_OVERVIEW)){
+        if (opts.isSet(DSC_REPORT_TITLE_OVERVIEW)) {
             overviewListTitle = opts.getValue(DSC_REPORT_TITLE_OVERVIEW);
         }
-        if (opts.isSet(DSC_REPORT_TITLE_ENTITIES)){
+        if (opts.isSet(DSC_REPORT_TITLE_ENTITIES)) {
             entitiesTitle = opts.getValue(DSC_REPORT_TITLE_ENTITIES);
         }
 
@@ -833,30 +822,31 @@ public class RepGen extends JCovCMDTool {
             return true;
         }
     }
+
     final static OptionDescr DSC_FMT =
             new OptionDescr("format", new String[]{"fmt"},
-            "Report generation output.", VAL_SINGLE,
-            "Specifies the format of the report.\n"
-            + "Use \"text\" for generate text report and \"html\" for generate HTML report\n"
-            + "Text report in one file which contains method/block/branch coverage information.\n"
-            + "HTML report contains coverage information with marked-up sources.\n\n"
-            + "Custom reports can be specified with ReportGeneratorSPI interface.", "html");
+                    "Report generation output.", VAL_SINGLE,
+                    "Specifies the format of the report.\n"
+                            + "Use \"text\" for generate text report and \"html\" for generate HTML report\n"
+                            + "Text report in one file which contains method/block/branch coverage information.\n"
+                            + "HTML report contains coverage information with marked-up sources.\n\n"
+                            + "Custom reports can be specified with ReportGeneratorSPI interface.", "html");
     /**
      *
      */
     public final static OptionDescr DSC_OUTPUT =
             new OptionDescr("repgen.output", new String[]{"output", "o"}, "", OptionDescr.VAL_SINGLE,
-            "Output directory for generating text and HTML reports.", "report");
+                    "Output directory for generating text and HTML reports.", "report");
     /**
      *
      */
     public final static OptionDescr DSC_TEST_LIST =
             new OptionDescr("tests", "Test list", OptionDescr.VAL_SINGLE,
-            "Specify the path to the file containing test list. File should contain a list of tests\n"
-            + "with one name per line.");
+                    "Specify the path to the file containing test list. File should contain a list of tests\n"
+                            + "with one name per line.");
     final static OptionDescr DSC_FILTER_PLUGIN =
             new OptionDescr("filter", "", OptionDescr.VAL_SINGLE,
-            "Custom filtering plugin class");
+                    "Custom filtering plugin class");
 
     final static OptionDescr DSC_ANC_FILTER_PLUGINS =
             new OptionDescr("ancfilter", new String[]{"ancf"}, "Custom anc filtering plugin classes", OptionDescr.VAL_MULTI,

--- a/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/DataMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,11 @@
  */
 package com.sun.tdk.jcov.instrument;
 
+import com.sun.tdk.jcov.data.Scale;
 import com.sun.tdk.jcov.instrument.asm.ASMModifiers;
 import com.sun.tdk.jcov.util.NaturalComparator;
-import com.sun.tdk.jcov.data.Scale;
 import com.sun.tdk.jcov.util.Utils;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -92,12 +93,12 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
      * @param differentiateMethods
      */
     DataMethod(final DataClass k,
-            final int access,
-            final String name,
-            final String desc,
-            final String signature,
-            final String[] exceptions,
-            final boolean differentiateMethods) {
+               final int access,
+               final String name,
+               final String desc,
+               final String signature,
+               final String[] exceptions,
+               final boolean differentiateMethods) {
         super(k.rootId);
 
         this.parent = k;
@@ -114,7 +115,6 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
      * Creates new DataMethod instance<br> Warning, this constructor adds
      * created object to <b>k</b> DataClass. Do not use this constructor in
      * iterators.
-     *
      */
     protected DataMethod(DataMethod other) {
         super(other.rootId);
@@ -126,6 +126,17 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
         this.signature = other.signature;
         this.exceptions = other.exceptions;
         this.differentiateMethods = other.differentiateMethods; // always false at the moment
+    }
+
+    /**
+     * This method clears the LineTable associated with the method.
+     * It can be used when switching from Java source line coverage to javap output line coverage.
+     *
+     * @return  the instance
+     */
+    public DataMethod clearLineTable() {
+        lineTable.clear();
+        return this;
     }
 
     /**
@@ -180,14 +191,17 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     }
 
     /**
-     * Get methods access code
-     * @return methods access code
+     * Get method's access code
+     *
+     * @return method's access code
      */
     public int getAccess() {
         return access.access();
     }
 
-    public Modifiers getModifiers() { return access; }
+    public Modifiers getModifiers() {
+        return access;
+    }
 
     /**
      * Get this method`s access flags as String array
@@ -201,8 +215,8 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Check whether <b>access</b> field has ACC_PUBLIC or ACC_PROTECTED flag
      *
-     * @see #getAccess()
      * @return true if <b>access</b> field has ACC_PUBLIC or ACC_PROTECTED flag
+     * @see #getAccess()
      */
     @Deprecated
     public boolean isPublic() {
@@ -212,8 +226,8 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Check whether <b>access</b> field has ACC_PUBLIC or ACC_PROTECTED flag
      *
-     * @see #getAccess()
      * @return true if <b>access</b> field has ACC_PUBLIC or ACC_PROTECTED flag
+     * @see #getAccess()
      */
     public boolean isPublicAPI() {
         return access.isPublic() || access.isProtected();
@@ -222,8 +236,8 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Check whether <b>access</b> field has ACC_ABSTRACT flag
      *
-     * @see #getAccess()
      * @return true if <b>access</b> field has ACC_ABSTRACT flag
+     * @see #getAccess()
      */
     @Deprecated
     public boolean isAbstract() {
@@ -304,7 +318,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Check whether this method was hit. When DataMethod is attached - data is
      * directly gotten from Collect class<br/><br/>
-     *
+     * <p>
      * Don't use it directly with DataMethodWithBlocks - it contains several
      * block. Loop through it's blocks instead.
      *
@@ -315,7 +329,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Check how many times this method was hit. When DataMethod is attached -
      * data is directly gotten from Collect class<br/><br/>
-     *
+     * <p>
      * Don't use it directly with DataMethodWithBlocks - it contains several
      * block. Loop through it's blocks instead. The first - MethEnter
      *
@@ -326,7 +340,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Set count of hits. If DataMethod is attached - data is directly written
      * to Collect class<br/><br/>
-     *
+     * <p>
      * Don't use it directly with DataMethodWithBlocks - it contains several
      * block. Loop through it's blocks instead.
      *
@@ -337,7 +351,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
     /**
      * Get scales information of this method. It's a bit mask telling which
      * testrun hit this method<br/><br/>
-     *
+     * <p>
      * Don't use it directly with DataMethodWithBlocks - it contains several
      * block. Loop through it's blocks instead.
      *
@@ -375,7 +389,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
 
     @Override
     public String toString() {
-        return super.toString() + "-" + name;
+        return "0x%04x %s".formatted(access.access(), getFullName());
     }
 
     /**
@@ -465,7 +479,7 @@ public abstract class DataMethod extends DataAnnotated implements Comparable<Dat
      */
     public void addLineEntry(int bci, int line) {
         if (lineTable == null) {
-            lineTable = new ArrayList<LineEntry>();
+            lineTable = new ArrayList<>();
         }
         lineTable.add(new LineEntry(bci, line));
     }

--- a/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,23 @@ import java.util.List;
  */
 public class LineCoverage extends CoverageData {
 
-    final HashMap<Long, Boolean> lines_hits = new HashMap<Long, Boolean>();
-    final HashMap<Long, Boolean> lines_ancs = new HashMap<Long, Boolean>();
+    final HashMap<Long, Boolean>  lines_hits = new HashMap<>();
+    final HashMap<Long, Boolean> lines_ancs = new HashMap<>();
 
     public LineCoverage() {
+    }
+
+    /**
+     * This method removes all from this line coverage.
+     * It can be used when switching from Java source line coverage to javap output line coverage.
+     *
+     * @return  the instance
+     */
+    public LineCoverage clear() {
+        covered = anc = total = 0;
+        lines_hits.clear();
+        lines_ancs.clear();
+        return this;
     }
 
     /**

--- a/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
+++ b/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1105,7 +1105,7 @@ public class CoverageReport implements ReportGenerator {
         String src = theClass.getSource();
         boolean isGenerate;
         File srcfile = null; // can be null
-        if (src == null || theClass.isJavapSource()) {
+        if (src == null || theClass.isJavapCoverage()) {
             isGenerate = false;
         } else {
             srcfile = new File(src);
@@ -1138,7 +1138,7 @@ public class CoverageReport implements ReportGenerator {
             }
         }
 
-        generateMemberTable(pw, theClass, "method", methodList, isGenerate, theClass.isJavapSource());
+        generateMemberTable(pw, theClass, "method", methodList, isGenerate, theClass.isJavapCoverage());
 
         List<FieldCoverage> fieldList = theClass.getFields();
         //Collections.sort((List) fieldList);
@@ -1149,7 +1149,7 @@ public class CoverageReport implements ReportGenerator {
                 methodsForLine.put(new Integer(startLine), fcov);
                 logger.log(Level.FINE, "{0}-{1}", new Object[]{fcov.getName(), startLine});
             }
-            generateMemberTable(pw, theClass, "field", fieldList, isGenerate, theClass.isJavapSource());
+            generateMemberTable(pw, theClass, "field", fieldList, isGenerate, theClass.isJavapCoverage());
         }
 
         if (isGenerate) {
@@ -1166,7 +1166,7 @@ public class CoverageReport implements ReportGenerator {
             pw.println(" </table>");
         }
 
-        if (theClass.isJavapSource()) {
+        if (theClass.isJavapCoverage()) {
             pw.println(" <table cellspacing=\"0\" cellpadding=\"0\" class=\"src\">");
             JavapClass javapClass = theClass.getJavapClass();
 
@@ -1176,7 +1176,7 @@ public class CoverageReport implements ReportGenerator {
 
                 methodsForLine = new HashMap<Integer, MemberCoverage>();
                 for (MethodCoverage mcov : methodList) {
-                    List<JavapLine> lines = javapClass.getMethod(mcov.getName() + mcov.getSignature());
+                    List<JavapLine> lines = javapClass.getMethod(mcov.getName(), mcov.getSignature());
                     if (lines != null) {
                         methodsForLine.put(lines.get(0).getLineNumber(), mcov);
                     }

--- a/src/classes/com/sun/tdk/jcov/report/javap/JavapRepGen.java
+++ b/src/classes/com/sun/tdk/jcov/report/javap/JavapRepGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ public class JavapRepGen {
                 List<JavapLine> methodLines;
                 JavapClass javapClass = classes.get(dataClass.getName());
                 if (javapClass != null) {
-                    methodLines = javapClass.getMethod(dataMethod.getName() + dataMethod.getVmSignature());
+                    methodLines = javapClass.getMethod(dataMethod.getName(), dataMethod.getVmSignature());
                 if (methodLines != null) {
                     for (JavapLine javapLine : methodLines) {
                         if ((javapLine instanceof JavapCodeLine) && visitedBlocksNumbers.contains(((JavapCodeLine) javapLine).getCodeNumber())) {


### PR DESCRIPTION
The Javap report had several issues marked in the picture below, which have been fixed:
![defectReport](https://github.com/user-attachments/assets/b8de7fc9-c59b-41f9-8300-700a1e24b533)
The expected report is:
![fixedReport](https://github.com/user-attachments/assets/e7aa1ef4-3bed-46d8-80eb-a6e2c87a6da2)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903842](https://bugs.openjdk.org/browse/CODETOOLS-7903842): Negative coverage in report for records (**Bug** - P2)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) (@shurymury - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jcov.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/48.diff">https://git.openjdk.org/jcov/pull/48.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/48#issuecomment-2397807083)
</details>
