### PR TITLE
7903875: Extend RecordContainerTest to also verify plain coverage report

### DIFF
--- a/test/unit/com/sun/tdk/jcov/report/RecordContainerTest.java
+++ b/test/unit/com/sun/tdk/jcov/report/RecordContainerTest.java
@@ -44,11 +44,11 @@ public class RecordContainerTest extends ReportTest {
         String[] copyClasses = {RecordContainer.class.getName(), RecordContainer.class.getName() + "$Point"};
         setup(RecordContainer.class, copyClasses);
         //prepare original bytecode
-        List<Path> classFiles = new Util(test_dir).copyBytecode(copyClasses);
+        new Util(test_dir).copyBytecode(copyClasses);
     }
 
     @Test
-    void textReport() throws IOException {
+    void javapReport() throws IOException {
         Path report = test_dir.resolve("report.javap");
         List<String> params = new ArrayList<>();
         params.add("-javap");
@@ -60,6 +60,26 @@ public class RecordContainerTest extends ReportTest {
         assertTrue(Files.isDirectory(report));
         Path classHtml = report.resolve(RecordContainer.class.getName().replace('.', '/') +
                 "$Point.html");
+        assertFalse(Files.readAllLines(classHtml).stream().anyMatch(l -> {
+            if (l.matches(".*<b>-\\d*</b>%\\(-\\d*/\\d*\\).*")) {
+                System.err.println("Found some negative coverage:");
+                System.err.println(l);
+                return true;
+            } else return false;
+        }));
+    }
+
+    @Test
+    void plainReport() throws IOException {
+        Path report = test_dir.resolve("report.plain");
+        List<String> params = new ArrayList<>();
+        params.add("-o");
+        params.add(report.toString());
+        params.add(result.toString());
+        new RepGen().run(params.toArray(new String[0]));
+        assertTrue(Files.isDirectory(report));
+        Path classHtml = report.resolve(RecordContainer.class.getName().replace('.', '/') +
+                ".html");
         assertFalse(Files.readAllLines(classHtml).stream().anyMatch(l -> {
             if (l.matches(".*<b>-\\d*</b>%\\(-\\d*/\\d*\\).*")) {
                 System.err.println("Found some negative coverage:");


### PR DESCRIPTION
…verage report

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903875](https://bugs.openjdk.org/browse/CODETOOLS-7903875): Extend RecordContainerTest to also verify plain coverage report (**Task** - P2)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jcov.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/53.diff">https://git.openjdk.org/jcov/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/53#issuecomment-2430354000)