### PR TITLE
7903733: Fixed an issue with incorrect coverage line statistics

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -334,8 +334,6 @@ MILESTONE="${build.milestone}"
         <mkdir dir="${result.dir}/test/classes" />
         <javac includeantruntime="false" encoding="iso-8859-1"
                debug="no"
-               target="8"
-               source="8"
                srcdir="${test.src.dir}"
                sourcepath="${test.src.dir}"
                classpath="${testngjar}:${build.dir}/jcov.jar"

--- a/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
@@ -135,8 +135,6 @@ public class LineCoverage extends CoverageData {
         if (wasHit != null) {
             if (!wasHit && isHit) {
                 ++covered;
-            } else if (wasHit && !isHit) {
-                --covered;
             }
             lines_hits.put(line, isHit || wasHit);
         } else {


### PR DESCRIPTION
The hited lines will be removed if isHit is false the next time the coverage is calculated, which will cause the actual number to be inconsistent with the green lines displayed in the coverage HTML report.

```
<meth name="&lt;init&gt;" vmsig="(IIJ)V" flags=' public' access="131073" cons="true" length="49">
				<bl s="0" e="48">
					<methenter s="0" e="48" id="636775" count="0"/>
					<exit s="48" e="48" opcode="return"/>
				</bl>
				<lt>0=138;4=94;15=111;22=139;28=140;42=141;48=142;</lt>
			</meth>
			<meth name="&lt;init&gt;" vmsig="(IJ)V" flags=' public' access="1" cons="true" length="35">
				<bl s="0" e="34">
					<methenter s="0" e="34" id="636776" count="107"/>
					<exit s="34" e="34" opcode="return"/>
				</bl>
				<lt>0=148;4=94;15=111;22=149;28=150;34=151;</lt>
			</meth>
			<meth name="&lt;init&gt;" vmsig="(J)V" flags=' public' access="1" cons="true" length="29">
				<bl s="0" e="28">
					<methenter s="0" e="28" id="636777" count="0"/>
					<exit s="28" e="28" opcode="return"/>
				</bl>
				<lt>0=156;4=94;15=111;22=157;28=158;</lt>
			</meth>
```
The above xml is taken from the test result xml file generated by jcov. It can be seen that in the three init, line 94 is run once, but the code will reduce the covered value by 1.

The problem is shown in the figure below. The line coverage is 55/101, but there are actually 59 green lines in the HTML report.
![image](https://github.com/user-attachments/assets/2ace64bc-8dad-4a0a-8def-85264bb6bbd0)

When I tried to execute the test, I found that there was a compilation problem. The reason was that Java8 could not recognize the record in the test code, so source/target=8 in build.xml should be removed. 
```
/home/lvfei.lv/workspace/github/Accelerator1996/jcov/test/unit/com/sun/tdk/jcov/report/RecordContainer.java:28: error: cannot find symbol
    [javac]     public record Point(int x, int y) {}
    [javac]            ^
    [javac]   symbol:   class record
    [javac]   location: class RecordContainer
    [javac] /home/lvfei.lv/workspace/github/Accelerator1996/jcov/test/unit/com/sun/tdk/jcov/instrument/ZipTest.java:96: error: cannot find symbol
    [javac]         var template_merge = test_dir.resolve("template_merge.xml");
    [javac]         ^
    [javac]   symbol:   class var
    [javac]   location: class ZipTest
```
In addition, due to the abnormality of the current instrument-related use case, I was unable to complete the supplement and self-test of the use case. I am very sorry.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [CODETOOLS-7903733](https://bugs.openjdk.org/browse/CODETOOLS-7903733)

### Issue
 * [CODETOOLS-7903733](https://bugs.openjdk.org/browse/CODETOOLS-7903733): [jcov]The number of covered lines displayed by jcov statistics is incorrect (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jcov.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/54.diff">https://git.openjdk.org/jcov/pull/54.diff</a>

</details>
