### PR TITLE
7903880: Check if JCov needs an update for security manager removal

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ asm.util.checksum = 9a3fb3a5cd6364dc5ca86d832093d7bcaa4ac927
 deps.dir=./lib
 
 # path to asm libraries
-asm.version=9.1
+asm.version=9.7.1
 asm.jar = ${deps.dir}/asm-${asm.version}.jar
 asm.tree.jar = ${deps.dir}/asm-tree-${asm.version}.jar
 asm.util.jar = ${deps.dir}/asm-util-${asm.version}.jar
@@ -52,4 +52,3 @@ result.dir =../JCOV_BUILD
 src.dir = ../src/classes
 # path to jcov test sources
 test.src.dir = ../test/unit
-

--- a/build/build.xml
+++ b/build/build.xml
@@ -30,7 +30,7 @@
     <property file="release.properties"/>
     <property file="build.properties"/>
     <import file="check-dependecies.xml"/>
-    
+
     <property environment="env"/>
 
     <!-- Build area -->
@@ -122,7 +122,7 @@
         <mkdir dir="${jcov.src.update}/com/sun/tdk/jcov/tools"/>
         <echo file="${jcov.src.update}/com/sun/tdk/jcov/tools/JcovVersion.java">
             /*
-            * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+            * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
             * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
             *
             * This code is free software; you can redistribute it and/or modify it

--- a/src/classes/com/sun/tdk/jcov/instrument/asm/OverriddenClassWriter.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/OverriddenClassWriter.java
@@ -28,8 +28,6 @@ import com.sun.tdk.jcov.JREInstr;
 import com.sun.tdk.jcov.runtime.PropertyFinder;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -228,10 +226,10 @@ public class OverriddenClassWriter extends ClassWriter {
         ClassInfo classInfo;
 
         if (loader instanceof JREInstr.StaticJREInstrClassLoader) {
-            InputStream in = getInputStreamForName(clName, loader, false, ".class");
+            InputStream in = getInputStreamForName(clName, loader, ".class");
 
             if (in == null) {
-                in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), false, ".class");
+                in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), ".class");
 
                 if (in == null) {
                     throw new IOException("Can't read class " + clName + " from classloader " + loader);
@@ -255,7 +253,7 @@ public class OverriddenClassWriter extends ClassWriter {
             return classInfo;
         }
 
-        InputStream in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), false, ".class");
+        InputStream in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), ".class");
         String superClassName = null;
         String[] interfaceNames = null;
         if (in == null){
@@ -279,11 +277,11 @@ public class OverriddenClassWriter extends ClassWriter {
 
         if (in == null && superClassName == null) {
 
-            in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), false, ".clazz");
+            in = getInputStreamForName(clName, ClassLoader.getSystemClassLoader(), ".clazz");
 
             if (in == null) {
                 if (!ClassLoader.getSystemClassLoader().equals(loader)) {
-                    in = getInputStreamForName(clName, loader, false, ".class");
+                    in = getInputStreamForName(clName, loader, ".class");
                     if (in != null) {
                         ClassReader cr = new OffsetLabelingClassReader(in);
                         classInfo = new ClassInfo(cr.getSuperName(), cr.getInterfaces());
@@ -320,10 +318,9 @@ public class OverriddenClassWriter extends ClassWriter {
      *
      * @param name
      * @param loader
-     * @param priveleged if false - will try to use doPriveleged() mode
      * @return
      */
-    private static InputStream getInputStreamForName(final String name, final ClassLoader loader, boolean priveleged, final String ext) {
+    private static InputStream getInputStreamForName(final String name, final ClassLoader loader, final String ext) {
         try {
             InputStream in = loader.getResourceAsStream(name + ext);
             if (in != null) {
@@ -339,16 +336,6 @@ public class OverriddenClassWriter extends ClassWriter {
                 if (in != null) return in;
             } catch (Throwable ignore) {}
         }
-
-        // trying to get class with priveleges
-        if (!priveleged) {
-            return AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
-                public InputStream run() {
-                    return getInputStreamForName(name, loader, true, ext);
-                }
-            });
-        }
-
         return null;
     }
 

--- a/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
+++ b/src/classes/com/sun/tdk/jcov/report/html/CoverageReport.java
@@ -1146,7 +1146,7 @@ public class CoverageReport implements ReportGenerator {
         if (showFields) {
             for (FieldCoverage fcov : fieldList) {
                 int startLine = fcov.getStartLine();
-                methodsForLine.put(new Integer(startLine), fcov);
+                methodsForLine.put(Integer.valueOf(startLine), fcov);
                 logger.log(Level.FINE, "{0}-{1}", new Object[]{fcov.getName(), startLine});
             }
             generateMemberTable(pw, theClass, "field", fieldList, isGenerate, theClass.isJavapCoverage());
@@ -1744,7 +1744,7 @@ public class CoverageReport implements ReportGenerator {
         boolean badNumber = false;
         double dvalue = 0;
         try {
-            dvalue = new Double(value.replace(',', '.')).doubleValue();
+            dvalue = Double.valueOf(value.replace(',', '.'));
             rest = 100d - (dvalue);
         } catch (NumberFormatException e) {
             badNumber = true;
@@ -1793,7 +1793,7 @@ public class CoverageReport implements ReportGenerator {
     }
 
     private String getRelativePath(String path) {
-        if (path != null && !path.equals("")) {
+        if (path != null && !path.isEmpty()) {
             // java.awt.event - ../../../
             return path.replace('.', '/').replaceAll("\\w+", "..") + "/";
         } else {


### PR DESCRIPTION
[7903880](https://bugs.openjdk.org/browse/CODETOOLS-7903880)
The fix removes leftovers from the security API (java.security.AccessController, java.security.PrivilegedAction) that work in conjunction with the Security Manager and are subject to removal in a future version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903880](https://bugs.openjdk.org/browse/CODETOOLS-7903880): Check if JCov needs an update for security manager removal (**Bug** - P2)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) (@shurymury - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jcov.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/57.diff">https://git.openjdk.org/jcov/pull/57.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/57#issuecomment-2638283653)
</details>
