### PR TITLE
7904005: Bump asm version to 9.8 to support JDK 25

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -30,7 +30,7 @@ asm.util.checksum = 9a3fb3a5cd6364dc5ca86d832093d7bcaa4ac927
 deps.dir=./lib
 
 # path to asm libraries
-asm.version=9.7.1
+asm.version=9.8
 asm.jar = ${deps.dir}/asm-${asm.version}.jar
 asm.tree.jar = ${deps.dir}/asm-tree-${asm.version}.jar
 asm.util.jar = ${deps.dir}/asm-util-${asm.version}.jar


### PR DESCRIPTION
The new ASM library was released:

```
29 March 2025: ASM 9.8 (tag ASM_9_8)
new Opcodes.V25 constant for Java 25
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904005](https://bugs.openjdk.org/browse/CODETOOLS-7904005): Bump asm version to 9.8 to support JDK 25 (**Bug** - P4)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jcov.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/58.diff">https://git.openjdk.org/jcov/pull/58.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/58#issuecomment-2855734596)
</details>
