### PR TITLE
Initialised i

### DIFF
--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
@@ -358,9 +358,8 @@ public class ClassMorph {
 //        adler.update(classfileBuffer, 0, classfileBuffer.length);
 //        long checksum = adler.getValue();
 //        return checksum;
-        int cp_count = ((classfileBuffer[i] & 0xFF) << 8) | (classfileBuffer[i + 1] & 0xFF);
-
         int i = 0;
+        int cp_count = ((classfileBuffer[i] & 0xFF) << 8) | (classfileBuffer[i + 1] & 0xFF);
         i += 4;//skip magic
         i += 4;//skip minor/major version
         i += 2;//skip constant pool count


### PR DESCRIPTION
https://github.com/judovana/jcov/commit/e2c20f0a9e94e5c7d0db51ac73f4249c02d9f58c moved the usage of `i` before its declaration. As its position aftyer i+=4 was wrong, moving before

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jcov.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/60.diff">https://git.openjdk.org/jcov/pull/60.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/60#issuecomment-2977217886)
</details>
