### PR TITLE
7904023: SHOULD NOT OCCUR: unknown cp_type

### DIFF
--- a/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
+++ b/src/classes/com/sun/tdk/jcov/instrument/asm/ClassMorph.java
@@ -361,9 +361,10 @@ public class ClassMorph {
         int i = 0;
         i += 4;//skip magic
         i += 4;//skip minor/major version
-        i += 2;//skip constant pool count
-
+        // get constant pool count
         int cp_count = ((classfileBuffer[i] & 0xFF) << 8) | (classfileBuffer[i + 1] & 0xFF);
+
+        i += 2;//skip constant pool count
 
         // Need to cache UTF8 values and their indexes to be able to resolve
         // method and attribute names


### PR DESCRIPTION
Fixing syntax error caused by last-minute code refactoring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904023](https://bugs.openjdk.org/browse/CODETOOLS-7904023): SHOULD NOT OCCUR: unknown cp_type (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.org/jcov.git pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/62.diff">https://git.openjdk.org/jcov/pull/62.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/62#issuecomment-2978052536)
</details>
