### PR TITLE
7904052: Allow JCov tests to be run by JTReg

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -352,4 +352,16 @@ MILESTONE="${build.milestone}"
             </classpath>
         </testng>
     </target>
+
+    <property name="tests" value="test/unit"/>
+
+    <target name="test-jtreg" depends="build-jcov,build-network.saver,build-file.saver">
+        <exec executable="${jtreg.home}/bin/jtreg" dir="..">
+            <arg value="-workDir:${result.dir}/JTwork"/>
+            <arg value="-reportDir:${result.dir}/JTreport"/>
+            <arg value="-cpa:${build.dir}/jcov.jar:${build.dir}/jcov_file_saver.jar"/>
+            <arg value="-v1"/>
+            <arg value="${tests}"/>
+        </exec>
+    </target>
 </project>

--- a/test/unit/TEST.ROOT
+++ b/test/unit/TEST.ROOT
@@ -1,0 +1,1 @@
+TestNG.dirs = .


### PR DESCRIPTION
JCov provides better isolation and better control over the execution environment.
For now I kept the testng test subject, up for discussion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904052](https://bugs.openjdk.org/browse/CODETOOLS-7904052): Allow JCov tests to be run by JTReg (**Task** - P3)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jcov.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/63.diff">https://git.openjdk.org/jcov/pull/63.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/63#issuecomment-3021080991)
</details>
