### PR TITLE
7904066: Make some plugin tests runnable with JTReg

### DIFF
--- a/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovCoverageComparison.java
+++ b/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovCoverageComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,9 +99,9 @@ public class JCovCoverageComparison implements FileCoverage {
                         String id = className + "#" + methodName;
                         var isOldMethod = oldSource == null || oldMethodsCache.containsKey(id);
                         DataMethod oldMethod = isOldMethod ? oldMethodsCache.get(id) : null;
-                        var newLineCoverage = new MethodCoverage(newMethod, true).getLineCoverage();
+                        var newLineCoverage = new MethodCoverage(newMethod, false).getLineCoverage();
                         var oldLineCoverage = isOld && isOldMethod ?
-                                new MethodCoverage(oldMethod, true).getLineCoverage() : null;
+                                new MethodCoverage(oldMethod, false).getLineCoverage() : null;
                         if(newFileSource.size() < newLineCoverage.lastLine() - 1) {
                             System.err.println("Wrong source for method " + className + "." + methodName);
                             System.err.println("    " + newLineCoverage.lastLine() + " lines expected but only " +
@@ -113,7 +113,7 @@ public class JCovCoverageComparison implements FileCoverage {
                                 repeatedLines = IntStream.range(0, newMethodSource.size()).toArray();
                             } else if (oldFileSource != null) {
                                 var oldMethodSource = isOld && isOldMethod ? methodSource(oldFileSource,
-                                        new MethodCoverage(oldMethod, true).getLineCoverage()) : null;
+                                        new MethodCoverage(oldMethod, false).getLineCoverage()) : null;
                                 repeatedLines = repeatedLines(oldMethodSource, newMethodSource, newLineCoverage);
                             } else repeatedLines = new int[0];
                             for (int ln : repeatedLines)

--- a/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovLineCoverage.java
+++ b/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovLineCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class JCovLineCoverage implements FileCoverage {
         var result = new HashMap<Integer, Boolean>();
         for (DataMethod m : cls.getMethods()) if (m instanceof DataMethodWithBlocks) {
             //TODO there is a copy-paste in other classes
-            var lc = new MethodCoverage(m, true).getLineCoverage();
+            var lc = new MethodCoverage(m, false).getLineCoverage();
             for (int i = (int)lc.firstLine(); i <= lc.lastLine(); i++) {
                 if (lc.isCode(i)) {
                     if (result.get(i) == null || !result.get(i).booleanValue())

--- a/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovMethodCoverageComparison.java
+++ b/plugins/coverage_reports/src/openjdk/codetools/jcov/report/jcov/JCovMethodCoverageComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ public class JCovMethodCoverageComparison implements FileItems {
 
     private static List<LineRange> methodRanges(DataMethod m) {
         Map<Integer, Boolean> result = new HashMap<>();
-        var lc = new MethodCoverage(m, true).getLineCoverage();
+        var lc = new MethodCoverage(m, false).getLineCoverage();
         for (int i = (int) lc.firstLine(); i <= lc.lastLine(); i++) {
             if (lc.isCode(i)) {
                 if (result.get(i) == null || !result.get(i).booleanValue())
@@ -130,8 +130,6 @@ public class JCovMethodCoverageComparison implements FileItems {
         private MethodItem(DataMethod method, String displayName, Quality quality) {
             this.id = displayName;
             this.quality = quality;
-            var lt = method.getLineTable();
-            var mc = new MethodCoverage(method, true);
             ranges = methodRanges(method);
         }
 

--- a/plugins/coverage_reports/test/TEST.ROOT
+++ b/plugins/coverage_reports/test/TEST.ROOT
@@ -1,0 +1,1 @@
+TestNG.dirs = .

--- a/plugins/coverage_reports/test/openjdk/codetools/jcov/report/jcov/JCovLoadTest.java
+++ b/plugins/coverage_reports/test/openjdk/codetools/jcov/report/jcov/JCovLoadTest.java
@@ -45,7 +45,8 @@ public class JCovLoadTest {
     static void init() throws FileFormatException, IOException {
         var xmlName = JCovLoadTest.class.getName().replace('.', '/');
         xmlName = "/" + xmlName.substring(0, xmlName.lastIndexOf('/')) + "/ObjectInputStream.xml";
-        coverage = new JCovLineCoverage(DataRoot.read(GitDifFilterTest.cp(xmlName).toString()), new SourceHierarchy() {
+        DataRoot data = DataRoot.read(GitDifFilterTest.cp(xmlName).toString());
+        coverage = new JCovLineCoverage(data, new SourceHierarchy() {
             @Override
             public List<String> readFile(String file) throws IOException {
                 return null;

--- a/plugins/simple_methods_anc/test/TEST.ROOT
+++ b/plugins/simple_methods_anc/test/TEST.ROOT
@@ -1,0 +1,1 @@
+TestNG.dirs = .


### PR DESCRIPTION
Adding necessary TEST.ROOT files.
Fixing up a few tests.
Fixing a problem in the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904066](https://bugs.openjdk.org/browse/CODETOOLS-7904066): Make some plugin tests runnable with JTReg (**Enhancement** - P3)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jcov.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/64.diff">https://git.openjdk.org/jcov/pull/64.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/64#issuecomment-3064207156)
</details>
