### PR TITLE
7904057: com/sun/tdk/jcov/report/RecordContainerTest.java test is failing

### DIFF
--- a/build/release.properties
+++ b/build/release.properties
@@ -23,4 +23,4 @@
 
 build.version = 3.0
 build.milestone = os.ea
-build.number = 14
+build.number = 15

--- a/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/LineCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,8 +148,6 @@ public class LineCoverage extends CoverageData {
         if (wasHit != null) {
             if (!wasHit && isHit) {
                 ++covered;
-            } else if (wasHit && !isHit) {
-                --covered;
             }
             lines_hits.put(line, isHit || wasHit);
         } else {

--- a/src/classes/com/sun/tdk/jcov/report/MethodCoverage.java
+++ b/src/classes/com/sun/tdk/jcov/report/MethodCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,16 +56,25 @@ public class MethodCoverage extends MemberCoverage implements Iterable<ItemCover
     private boolean isInAnc = false;
     protected String ancInfo;
 
-    public MethodCoverage(DataMethod method, boolean countBlocks) {
-        this(method, countBlocks, null, null);
+    /**
+     * Creates a new MethodCoverage instance for the given DataMethod.
+     *
+     * @param method the DataMethod for which to create the MethodCoverage instance
+     * @param isJavapCoverage a boolean indicating whether the coverage is based on Javap output
+     */
+    public MethodCoverage(DataMethod method, boolean isJavapCoverage) {
+        this(method, isJavapCoverage, null, null);
     }
 
     /**
-     * <p> Creates new MethodCoverage instance </p>
+     * <p> Creates a new MethodCoverage instance for the given DataMethod. </p>
      *
-     * @param method
+     * @param method the DataMethod for which to create the MethodCoverage instance
+     * @param isJavapCoverage a boolean indicating whether the coverage is based on Javap output
+     * @param ancFilters an array of AncFilter objects used to filter out certain blocks or branches
+     * @param ancReason a string representing the reason for excluding certain blocks or branches
      */
-    public MethodCoverage(DataMethod method, boolean javapCoverage, AncFilter[] ancFilters, String ancReason) {
+    public MethodCoverage(DataMethod method, boolean isJavapCoverage, AncFilter[] ancFilters, String ancReason) {
         this.dataMethod = method;
         access = method.getAccess();
         modifiersString = Arrays.deepToString(method.getAccessFlags());
@@ -80,13 +89,18 @@ public class MethodCoverage extends MemberCoverage implements Iterable<ItemCover
         ancInfo = ancReason;
 
         detectItems(method, items, isInAnc, ancFilters);
-        if( !javapCoverage ) {
+        if( !isJavapCoverage ) {
             setLineCoverage();
         } // else Javap line coverage is calculated in ClassCoverage.setJavapLineCoverage(JavapClass javapClass)
     }
 
     /**
-     * Sets the line coverage for the method.
+     * Sets the line coverage for the method based on the line table information
+     * associated with the underlying DataMethod. It processes the line table
+     * and updates the line coverage accordingly. If an item is covered, it
+     * marks the corresponding lines as hit. If an item is not covered and is
+     * marked as 'in Anc' (Ancillary), it marks the corresponding lines as
+     * ancillary. It also sets the source line for each item if not already set.
      */
     public void setLineCoverage() {
         List<LineEntry> lineTable = dataMethod.getLineTable();

--- a/test/unit/com/sun/tdk/jcov/report/CoverageTarget.java
+++ b/test/unit/com/sun/tdk/jcov/report/CoverageTarget.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.report;
+
+public class CoverageTarget {
+
+    public static void main(String[] args) {
+        CoverageTarget target = new CoverageTarget();
+
+        target.testBranching(5);
+        target.testLoop(3);
+        target.testSwitch("c");
+        target.testExceptionHandling(true);
+        target.testTryWithResources();
+        target.useLambda(() -> "Lambda result");
+        System.out.println("Inner: " + target.new InnerClass().compute());
+    }
+
+    public int testBranching(int x) {
+        if (x > 10) {
+            return x * 2;
+        } else if (x > 5) {
+            return x + 10;
+        } else {
+            return x - 1;
+        }
+    }
+
+    public int testLoop(int n) {
+        int result = 0;
+        for (int i = 0; i < n; i++) {
+            if (i % 2 == 0) {
+                result += i;
+            } else {
+                result -= i;
+            }
+        }
+        int i = 0;
+        while (i < 2) {
+            result += i;
+            i++;
+        }
+        return result;
+    }
+
+    public String testSwitch(String input) {
+        switch (input) {
+            case "a":
+                return "A";
+            case "b":
+                return "B";
+            case "c":
+                return "C";
+            default:
+                return "Unknown";
+        }
+    }
+
+    public String testExceptionHandling(boolean shouldThrow) {
+        try {
+            if (shouldThrow) {
+                throw new IllegalArgumentException("Test exception");
+            }
+            return "No exception";
+        } catch (IllegalArgumentException e) {
+            return "Caught: " + e.getMessage();
+        } finally {
+            System.out.println("In finally block");
+        }
+    }
+
+    public String testTryWithResources() {
+        try (DummyResource res = new DummyResource()) {
+            res.use();
+            return "Resource used";
+        } catch (Exception e) {
+            return "Exception during resource use";
+        }
+    }
+
+    public String useLambda(Supplier<String> supplier) {
+        return supplier.get();
+    }
+
+    public class InnerClass {
+        public int compute() {
+            return 42;
+        }
+    }
+
+    static class DummyResource implements AutoCloseable {
+        public void use() {
+            System.out.println("Using resource");
+        }
+
+        @Override
+        public void close() {
+            System.out.println("Closing resource");
+        }
+    }
+
+    @FunctionalInterface
+    public interface Supplier<T> {
+        T get();
+    }
+}

--- a/test/unit/com/sun/tdk/jcov/report/CoverageTargetTest.java
+++ b/test/unit/com/sun/tdk/jcov/report/CoverageTargetTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.tdk.jcov.report;
+
+import com.sun.tdk.jcov.RepGen;
+import com.sun.tdk.jcov.instrument.Util;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+public class CoverageTargetTest extends ReportTest {
+
+    private String testClassName = CoverageTarget.class.getName();
+
+    @BeforeClass
+    void setup() throws Exception {
+        String[] copyClasses = {testClassName,
+                testClassName + "$DummyResource",
+                testClassName + "$InnerClass",
+                testClassName + "$Supplier"};
+        setup(CoverageTarget.class, copyClasses);
+        //prepare original bytecode
+        new Util(test_dir).copyBytecode(copyClasses);
+    }
+
+    @Test
+    void plainReport() throws IOException {
+        Path report = test_dir.resolve("report.plain");
+        List<String> params = new ArrayList<>();
+        params.add("-o");
+        params.add(report.toString());
+        params.add(result.toString());
+        new RepGen().run(params.toArray(new String[0]));
+        assertTrue(Files.isDirectory(report));
+        Path classHtml = report.resolve(testClassName.replace('.', '/') + ".html");
+        assertTrue(Files.readAllLines(classHtml).stream().anyMatch(l -> l.contains("<b>84</b>%(42/50)")));
+    }
+
+}


### PR DESCRIPTION
[CODETOOLS-7904057](https://bugs.openjdk.org/browse/CODETOOLS-7904057): com/sun/tdk/jcov/report/RecordContainerTest.java test is failing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904057](https://bugs.openjdk.org/browse/CODETOOLS-7904057): com/sun/tdk/jcov/report/RecordContainerTest.java test is failing (**Bug** - P2)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewers without OpenJDK IDs
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jcov.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/65.diff">https://git.openjdk.org/jcov/pull/65.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/65#issuecomment-3152517406)
</details>
