### PR TITLE
7904097: Use asm 9.9 in order to support JDK 26

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ asm.util.checksum = 9a3fb3a5cd6364dc5ca86d832093d7bcaa4ac927
 deps.dir=./lib
 
 # path to asm libraries
-asm.version=9.8
+asm.version=9.9
 asm.jar = ${deps.dir}/asm-${asm.version}.jar
 asm.tree.jar = ${deps.dir}/asm-tree-${asm.version}.jar
 asm.util.jar = ${deps.dir}/asm-util-${asm.version}.jar


### PR DESCRIPTION
Simple bumping up of the asm version. Testing: local, coverage gathering in both agent and separate app modes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904097](https://bugs.openjdk.org/browse/CODETOOLS-7904097): Use asm 9.9 in order to support JDK 26 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jcov.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/66.diff">https://git.openjdk.org/jcov/pull/66.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/66#issuecomment-3402644436)
</details>
