### PR TITLE
7904098: Allow experimental ASM build in the JCov build

### DIFF
--- a/build/check-dependecies.xml
+++ b/build/check-dependecies.xml
@@ -74,7 +74,18 @@
 
     <target name="verify-dependencies" depends="download-dependencies, download-javatest, verify-asm, verify-asm-tree, verify-asm-util"/>
 
-    <target name="download-dependencies">
+    <target name="check-dependencies-downloaded">
+        <condition property="asm.downloaded">
+            <and>
+                <available file="${asm.jar}"/>
+                <available file="${asm.tree.jar}"/>
+                <available file="${asm.util.jar}"/>
+            </and>
+        </condition>
+        <available file="${javatestjar}" property="javatest.downloaded"/>
+    </target>
+
+    <target name="download-dependencies" unless="asm.downloaded" depends="check-dependencies-downloaded">
         <mkdir dir="${deps.dir}"/>
         <basename property="asm.jar.filename" file="${asm.jar}"/>
         <basename property="asm.tree.jar.filename" file="${asm.tree.jar}"/>
@@ -84,18 +95,29 @@
         <get src="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-util/${asm.version}/${asm.util.jar.filename}" dest="${asm.util.jar}" skipexisting="true"/>
     </target>
 
-   <target name="download-javatest" if="javatest.present" description="build jtobserver jar">
+    <target name="download-javatest" if="javatest.present" unless="javatest.downloaded" description="build jtobserver jar" depends="check-dependencies-downloaded">
         <mkdir dir="${deps.dir}"/>
         <basename property="javatestjar.filename" file="${javatestjar}"/>
-       <get src="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtharness/${javatestjar.filename}" dest="${javatestjar}" skipexisting="true"/>
-   </target>
+        <get src="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtharness/${javatestjar.filename}" dest="${javatestjar}" skipexisting="true"/>
+    </target>
 
-    <target name="download-test-dependencies">
+    <target name="check-test-dependencies-downloaded">
+        <available file="${testngjar}" property="testng.downloaded"/>
+        <available file="${jcommanderjar}" property="jcommander.downloaded"/>
+    </target>
+
+    <target name="download-testng" unless="testng.downloaded" depends="check-test-dependencies-downloaded">
         <mkdir dir="${deps.dir}"/>
         <basename property="testngjar.filename" file="${testngjar}"/>
+        <get src="https://repo1.maven.org/maven2/org/testng/testng/${testngver}/${testngjar.filename}" dest="${testngjar}" skipexisting="true"/>
+    </target>
+
+    <target name="download-jcommander" unless="jcommander.downloaded" depends="check-test-dependencies-downloaded">
+        <mkdir dir="${deps.dir}"/>
         <basename property="jcommanderjar.filename" file="${jcommanderjar}"/>
-       <get src="https://repo1.maven.org/maven2/org/testng/testng/${testngver}/${testngjar.filename}" dest="${testngjar}" skipexisting="true"/>
-       <get src="https://repo1.maven.org/maven2/com/beust/jcommander/${jcommanderver}/${jcommanderjar.filename}" dest="${jcommanderjar}" skipexisting="true"/>
-   </target>
+        <get src="https://repo1.maven.org/maven2/com/beust/jcommander/${jcommanderver}/${jcommanderjar.filename}" dest="${jcommanderjar}" skipexisting="true"/>
+    </target>
+
+    <target name="download-test-dependencies" depends="download-testng,download-jcommander"/>
 
 </project>


### PR DESCRIPTION
This change allows an arbitrary ASM build to be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904098](https://bugs.openjdk.org/browse/CODETOOLS-7904098): Allow experimental ASM build in the JCov build (**Enhancement** - P2)


### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) - **Reviewer** ⚠️ Added manually

### Reviewers without OpenJDK IDs
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/jcov.git pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/67.diff">https://git.openjdk.org/jcov/pull/67.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/67#issuecomment-3412276767)
</details>
