### PR TITLE
7904091: javap report fails if includes interfaces

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -164,13 +164,13 @@
     <target name="compile"  depends="prepare, build-date"
             description="compile main tools">
 
-        <javac includeantruntime="false" encoding="iso-8859-1" debug="true" target="8" source="8"
+        <javac includeantruntime="false" encoding="iso-8859-1" debug="true"
                srcdir="${jcov.src.update}"
                destdir="${jcov.classes}"
                classpath="${jcov.classpath}">
         </javac>
 
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true"
                srcdir="${src.dir}"
                destdir="${jcov.classes}"
                classpath="${jcov.classpath}">
@@ -236,7 +236,7 @@
                 </tokenfilter>
             </filterchain>
         </copy>
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true"
                srcdir="${jcov.filesaver.src}"
                sourcepath=""
                classpath="${jcov.filesaver.classes}"
@@ -270,7 +270,7 @@
                 </tokenfilter>
             </filterchain>
         </copy>
-        <javac includeantruntime="true" encoding="iso-8859-1" debug="true" target="8" source="8"
+        <javac includeantruntime="true" encoding="iso-8859-1" debug="true"
                srcdir="${jcov.networksaver.src}"
                sourcepath=""
                classpath="${jcov.networksaver.classes}"
@@ -289,8 +289,6 @@
         <mkdir dir="${jcov.jtobserver.classes}"/>
         <javac includeantruntime="false" encoding="iso-8859-1"
                debug="no"
-               target="8"
-               source="8"
                srcdir="${src.dir}"
                sourcepath=""
                destdir="${jcov.jtobserver.classes}" classpath="${javatestjar}">
@@ -334,8 +332,6 @@ MILESTONE="${build.milestone}"
         <mkdir dir="${result.dir}/test/classes" />
         <javac includeantruntime="false" encoding="iso-8859-1"
                debug="no"
-               target="8"
-               source="8"
                srcdir="${test.src.dir}"
                sourcepath="${test.src.dir}"
                classpath="${testngjar}:${build.dir}/jcov.jar"

--- a/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
+++ b/src/classes/com/sun/tdk/jcov/insert/AbstractUniversalInstrumenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,26 +26,17 @@ package com.sun.tdk.jcov.insert;
 
 import com.sun.tdk.jcov.instrument.asm.OverriddenClassWriter;
 import com.sun.tdk.jcov.util.Utils;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+
+import java.io.*;
 import java.net.URI;
 import java.nio.file.*;
+import java.nio.file.FileSystem;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.CRC32;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
+import java.util.zip.*;
 
 import static com.sun.tdk.jcov.util.Utils.FILE_TYPE;
 import static com.sun.tdk.jcov.util.Utils.FILE_TYPE.*;
@@ -54,10 +45,11 @@ import static com.sun.tdk.jcov.util.Utils.isClassFile;
 /**
  * The class is resposible to deal with class files and hierarchies of files, such as directories, jars, zips, modules.
  * The actual logic of bytecode instrumentation is left for subclasses of this class.
- * @see #instrument(byte[], int)
- * @see #finishWork()
+ *
  * @author Dmitry Fazunenko
  * @author Alexey Fedorchenko
+ * @see #instrument(byte[], int)
+ * @see #finishWork()
  */
 public abstract class AbstractUniversalInstrumenter {
 
@@ -209,6 +201,10 @@ public abstract class AbstractUniversalInstrumenter {
             if (outFile == null) {
                 outFile = f;
                 f.delete();
+            }
+            if (outFile.isDirectory()) {
+                // if outFile is a directory, then use the original file name
+                outFile = new File(outFile, f.getName());
             }
 
             // create "super" directories if necessary
@@ -800,5 +796,5 @@ public abstract class AbstractUniversalInstrumenter {
             }
         }
         in.close();
-        }
+    }
 }

--- a/src/classes/com/sun/tdk/jcov/report/javap/JavapRepGen.java
+++ b/src/classes/com/sun/tdk/jcov/report/javap/JavapRepGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,13 +150,25 @@ public class JavapRepGen {
         for (File classFile : classFiles) {
             JavapClass javapClass = new JavapClass();
             javapClass.parseJavapFile(classFile.getAbsolutePath(), null);
-            classes.put(javapClass.getClassName(), javapClass);
+            String className = javapClass.getClassName();
+            if (className.isEmpty()) {
+                JavapRepGen.printErrorMsg("Failed to extract class or interface name from javap output: \"javap -c %s\"".
+                        formatted(classFile.getAbsolutePath()));
+            } else {
+                classes.put(className, javapClass);
+            }
         }
 
         for (String classFileInJar : classFilesInJar) {
             JavapClass javapClass = new JavapClass();
             javapClass.parseJavapFile(classFileInJar, rootFile.getAbsolutePath());
-            classes.put(javapClass.getClassName(), javapClass);
+            String className = javapClass.getClassName();
+            if (className.isEmpty()) {
+                JavapRepGen.printErrorMsg("Failed to extract class or interface name from javap output: \"javap -c %s:%s\"".
+                        formatted(rootFile.getAbsolutePath(), classFileInJar));
+            } else {
+                classes.put(className, javapClass);
+            }
         }
 
         //reading block and branch coverage and mark lines in javap classes.

--- a/test/unit/com/sun/tdk/jcov/report/CoverageTarget.java
+++ b/test/unit/com/sun/tdk/jcov/report/CoverageTarget.java
@@ -24,12 +24,12 @@
  */
 package com.sun.tdk.jcov.report;
 
-public class CoverageTarget {
+public class CoverageTarget implements ICoverage, ITarget {
 
     public static void main(String[] args) {
         CoverageTarget target = new CoverageTarget();
 
-        target.testBranching(5);
+        target.testBranching(SIZES[0]);
         target.testLoop(3);
         target.testSwitch("c");
         target.testExceptionHandling(true);
@@ -40,7 +40,7 @@ public class CoverageTarget {
 
     public int testBranching(int x) {
         if (x > 10) {
-            return x * 2;
+            return x * size();
         } else if (x > 5) {
             return x + 10;
         } else {
@@ -51,14 +51,14 @@ public class CoverageTarget {
     public int testLoop(int n) {
         int result = 0;
         for (int i = 0; i < n; i++) {
-            if (i % 2 == 0) {
+            if (i % size() == 0) {
                 result += i;
             } else {
                 result -= i;
             }
         }
         int i = 0;
-        while (i < 2) {
+        while (i < size()) {
             result += i;
             i++;
         }

--- a/test/unit/com/sun/tdk/jcov/report/CoverageTargetTest.java
+++ b/test/unit/com/sun/tdk/jcov/report/CoverageTargetTest.java
@@ -40,10 +40,14 @@ import static org.testng.Assert.assertTrue;
 public class CoverageTargetTest extends ReportTest {
 
     private String testClassName = CoverageTarget.class.getName();
+    private String intfCoverageName = ICoverage.class.getName();
+    private String intfTargetName = ITarget.class.getName();
 
     @BeforeClass
     void setup() throws Exception {
         String[] copyClasses = {testClassName,
+                intfCoverageName,
+                intfTargetName,
                 testClassName + "$DummyResource",
                 testClassName + "$InnerClass",
                 testClassName + "$Supplier"};
@@ -62,7 +66,23 @@ public class CoverageTargetTest extends ReportTest {
         new RepGen().run(params.toArray(new String[0]));
         assertTrue(Files.isDirectory(report));
         Path classHtml = report.resolve(testClassName.replace('.', '/') + ".html");
-        assertTrue(Files.readAllLines(classHtml).stream().anyMatch(l -> l.contains("<b>84</b>%(42/50)")));
+        assertTrue(Files.readAllLines(classHtml).stream().anyMatch(l -> l.contains("<b>82</b>%(41/50)")));
     }
 
-}
+    @Test
+    void javapReport() throws IOException {
+        Path report = test_dir.resolve("report.javap");
+        List<String> params = new ArrayList<>();
+        params.add("-javap");
+        params.add(test_dir.toString());
+        params.add("-o");
+        params.add(report.toString());
+        params.add(result.toString());
+        new RepGen().run(params.toArray(new String[0]));
+        assertTrue(Files.isDirectory(report));
+        Path classHtml = report.resolve(intfCoverageName.replace('.', '/') + ".html");
+        assertTrue(Files.readAllLines(classHtml).stream().anyMatch(l -> l.contains("<b>100</b>%(2/2)")));
+        classHtml = report.resolve(intfTargetName.replace('.', '/') + ".html");
+        assertTrue(Files.readAllLines(classHtml).stream().anyMatch(l -> l.contains("<b>100</b>%(16/16)")));
+    }
+ }

--- a/test/unit/com/sun/tdk/jcov/report/ICoverage.java
+++ b/test/unit/com/sun/tdk/jcov/report/ICoverage.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package com.sun.tdk.jcov.report;
+
+public interface ICoverage {
+    default int size() {
+        return 2;
+    }
+}

--- a/test/unit/com/sun/tdk/jcov/report/ITarget.java
+++ b/test/unit/com/sun/tdk/jcov/report/ITarget.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package com.sun.tdk.jcov.report;
+
+public interface ITarget {
+    int[] SIZES = { 16, 24, 32 };
+}


### PR DESCRIPTION
[CODETOOLS-7904091](https://bugs.openjdk.org/browse/CODETOOLS-7904091): javap report fails if includes interfaces

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904091](https://bugs.openjdk.org/browse/CODETOOLS-7904091): javap report fails if includes interfaces (**Bug** - P2)


### Reviewers
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewers without OpenJDK IDs
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jcov.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jcov.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jcov/pull/68.diff">https://git.openjdk.org/jcov/pull/68.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jcov/pull/68#issuecomment-3519953982)
</details>
